### PR TITLE
Widen the role: search to roles:

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -5,7 +5,7 @@
 #
 include_recipe "logstash::default"
 
-logstash_server = search(:node, "role:#{node[:logstash][:agent][:server_role]} AND chef_environment:#{node.chef_environment}")
+logstash_server = search(:node, "roles:#{node[:logstash][:agent][:server_role]} AND chef_environment:#{node.chef_environment}")
 
 directory "#{node[:logstash][:basedir]}/agent" do
   action :create

--- a/recipes/kibana.rb
+++ b/recipes/kibana.rb
@@ -2,7 +2,7 @@ include_recipe "apache2"
 include_recipe "apache2::mod_php5"
 include_recipe "php::module_curl"
 
-es_server = search(:node, "role:#{node[:logstash][:kibana][:elasticsearch_role]} AND chef_environment:#{node.chef_environment}")
+es_server = search(:node, "roles:#{node[:logstash][:kibana][:elasticsearch_role]} AND chef_environment:#{node.chef_environment}")
 kibana_version = node[:logstash][:kibana][:sha]
 
 apache_module "php5" do

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -5,8 +5,8 @@
 #
 include_recipe "logstash::default"
 
-graphite_server = search(:node, "role:#{node[:logstash][:graphite_role]} AND chef_environment:#{node.chef_environment}")
-elasticsearch_server = search(:node, "role:#{node[:logstash][:elasticsearch_role]} AND chef_environment:#{node.chef_environment}")
+graphite_server = search(:node, "roles:#{node[:logstash][:graphite_role]} AND chef_environment:#{node.chef_environment}")
+elasticsearch_server = search(:node, "roles:#{node[:logstash][:elasticsearch_role]} AND chef_environment:#{node.chef_environment}")
 
 directory "#{node[:logstash][:basedir]}/server" do
   action :create

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -8,7 +8,7 @@ package "wget"
 
 logstash_version = node[:logstash][:source][:sha]
 
-#logstash_server = search(:node, "role:#{node[:logstash][:agent][:server_role]} AND chef_environment:#{node.chef_environment}").first
+#logstash_server = search(:node, "roles:#{node[:logstash][:agent][:server_role]} AND chef_environment:#{node.chef_environment}").first
 
 directory "#{node[:logstash][:basedir]}/source" do
   action :create


### PR DESCRIPTION
role:example means the role needs to be in the nodes top-level runlist, where
roles:example will search the expanded runlist, which fits our house style.

http://wiki.opscode.com/display/chef/Search#Search-FindNodeswithaRoleintheExpandedRunList
