### PR TITLE
Add :base_config_cookbook option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Attributes
 * `node[:logstash][:agent][:source_url]` - The URL of the Logstash jar to download. Only applies to `jar` install method.
 * `node[:logstash][:agent][:checksum]` - The checksum of the jar file. Only applies to `jar` install method.
 * `node[:logstash][:agent][:base_config]` - The name of the template to use for `logstash.conf` as a base config.
+* `node[:logstash][:agent][:base_config_cookbook]` - Where to find the base\_config template.
 * `node[:logstash][:agent][:xms]` - The minimum memory to assign the JVM.
 * `node[:logstash][:agent][:xmx]` - The maximum memory to assign the JVM.
 * `node[:logstash][:agent][:debug]` - Run logstash with `-v` option?
@@ -52,6 +53,7 @@ Attributes
 * `node[:logstash][:server][:source_url]` - The URL of the Logstash jar to download. Only applies to `jar` install method.
 * `node[:logstash][:server][:checksum]` - The checksum of the jar file. Only applies to `jar` install method.
 * `node[:logstash][:server][:base_config]` - The name of the template to use for `logstash.conf` as a base config.
+* `node[:logstash][:server][:base_config_cookbook]` - Where to find the base\_config template.
 * `node[:logstash][:server][:xms]` - The minimum memory to assign the JVM.
 * `node[:logstash][:server][:xmx]` - The maximum memory to assign the JVM.
 * `node[:logstash][:server][:debug]` - Run logstash with `-v` option?

--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -3,6 +3,7 @@ default['logstash']['agent']['source_url'] = 'http://databits.net/petef/tmp/logs
 default['logstash']['agent']['checksum'] = '6ca41718706c118ee6abb339bec9225b5d56cc3dc258d5053e64d00e24cdb918'
 default['logstash']['agent']['install_method'] = "jar" # Either `source` or `jar`
 default['logstash']['agent']['base_config'] = "agent.conf.erb"
+default['logstash']['agent']['base_config_cookbook'] = "logstash"
 default['logstash']['agent']['xms'] = "384M"
 default['logstash']['agent']['xmx'] = "384M"
 default['logstash']['agent']['debug'] = false

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -4,6 +4,7 @@ default['logstash']['server']['source_url'] = 'http://databits.net/petef/tmp/log
 default['logstash']['server']['checksum'] = '6ca41718706c118ee6abb339bec9225b5d56cc3dc258d5053e64d00e24cdb918'
 default['logstash']['server']['install_method'] = "jar" # Either `source` or `jar`
 default['logstash']['server']['base_config'] = "server.conf.erb"
+default['logstash']['server']['base_config_cookbook'] = "logstash"
 default['logstash']['server']['xms'] = "1024M"
 default['logstash']['server']['xmx'] = "1024M"
 default['logstash']['server']['debug'] = false

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -92,6 +92,7 @@ end
 
 template "#{node['logstash']['basedir']}/agent/etc/shipper.conf" do
   source node['logstash']['agent']['base_config']
+  cookbook node['logstash']['agent']['base_config_cookbook']
   owner node['logstash']['user']
   group node['logstash']['group']
   mode "0644"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -106,6 +106,7 @@ end
 
 template "#{node['logstash']['basedir']}/server/etc/logstash.conf" do
   source node['logstash']['server']['base_config']
+  cookbook node['logstash']['server']['base_config_cookbook']
   owner node['logstash']['user']
   group node['logstash']['group']
   mode "0644"


### PR DESCRIPTION
This allows a user to keep the logstash cookbook pristine, and override the
agent/server config template via a site cookbook.
