### PR TITLE
Fix elsif comparison

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -50,9 +50,9 @@ directory "#{node['logstash']['basedir']}/agent/etc/patterns" do
 end
 
 
-if platform_family?  "debian"
+if platform?  "debian", "ubuntu"
   runit_service "logstash_agent"
-elsif "rhel"
+elsif platform? "redhat", "centos", "amazon", "fedora"
   template "/etc/init.d/logstash_agent" do
     source "init.erb"
     owner "root"


### PR DESCRIPTION
Hi,

The method that says the current platform at the `elsif` stament at the `agent.rb` recipe was missing, so the condition always fails.
I also changed `platform_family?` by `platform?` as in tha `server.rb` recipe, so it can work with older Chef versions.

Cheers
