### PR TITLE
Should include the git recipe in case it's the only recipe being run.

### DIFF
--- a/recipes/kibana.rb
+++ b/recipes/kibana.rb
@@ -1,6 +1,7 @@
 include_recipe "apache2"
 include_recipe "apache2::mod_php5"
 include_recipe "php::module_curl"
+include_recipe "git"
 
 
 if Chef::Config[:solo]


### PR DESCRIPTION
Ran into an situation where the kabana recipe failed run because git wasn't installed. Added the include. 
