### PR TITLE
Searching for server ip by role breaks for those of us not using roles.  Let's fix this.

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -5,14 +5,16 @@
 #
 include_recipe "logstash::default"
 
-# check if running chef-solo
+# check if running chef-solo.  If not, detect the logstash server/ip by role.  If I can't do that, fall back to using ['logstash']['agent']['server_ipaddress']
 if Chef::Config[:solo]
   logstash_server_ip = node['logstash']['agent']['server_ipaddress']
-else
-  logstash_server_results = search(:node, "roles:#{node['logstash']['agent']['server_role']}")
-  unless logstash_server_results.empty?
-    logstash_server_ip = logstash_server_results[0]['ipaddress']
-  end
+else 
+logstash_server_results = search(:node, "roles:#{node['logstash']['agent']['server_role']}")
+    unless logstash_server_results.empty?
+        logstash_server_ip = logstash_server_results[0]['ipaddress']
+    else 
+        logstash_server_ip = node['logstash']['agent']['server_ipaddress']
+    end
 end
   
 directory "#{node['logstash']['basedir']}/agent" do


### PR DESCRIPTION
My org doesn't use roles the same as most people.  We're of the philosophy that roles should be avoided except in rare cases where you want something universal across all environments that you cannot version-pin the same as you can with a cookbook.  We essentially use cookbooks for our attributes and run lists so we can keep changes to them in version control and pin those changes per environment.  In this case, we don't want to have the need to create roles as a simple pointer to a box, we build logic in our wrapper recipes to set [:logstash][:agent][:server_ipaddress].  Others may find it useful to do so as well.  I've made the changes to fall back to this if we fail searching for a node by role.
