### PR TITLE
Manual IP Setting outside of Solo

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -5,10 +5,10 @@
 #
 include_recipe "logstash::default"
 
-# check if running chef-solo
-if Chef::Config[:solo]
-  logstash_server_ip = node['logstash']['agent']['server_ipaddress']
-else
+# Allow us to set a default server ip
+logstash_server_ip = node['logstash']['agent']['server_ipaddress']
+# But override with search results if available
+unless Chef::Config[:solo]
   logstash_server_results = search(:node, "roles:#{node['logstash']['agent']['server_role']}")
   unless logstash_server_results.empty?
     logstash_server_ip = logstash_server_results[0]['ipaddress']


### PR DESCRIPTION
I have a scenario where the logstash server isn't in the chef organization, so I need to use the ip address attribute outside of a solo run. Refactored the code slightly to allow for this.
