### PR TITLE
rewrite config generation template to allow for complex inputs and filters

### DIFF
--- a/templates/default/server.conf.erb
+++ b/templates/default/server.conf.erb
@@ -1,68 +1,78 @@
 input {
-  <% if  node['logstash']['server']['inputs'].empty? -%>
+<% if  node['logstash']['server']['inputs'].empty? -%>
   tcp {
     type => "tcp-input"
     port => "5959"
     format => "json_event"
   }
-  <% else %>    
-    <% node['logstash']['server']['inputs'].each do |input| -%>
-     
-        <% input.each do |name,hash| -%> 
-             <%= name %> {
-                 <% hash.each do |k,v| -%>         
-                       <%= k %> => '<%= v %>'
-                 <% end -%>
-        <% end -%>
-        }
-     <% end -%>
-  <% end -%>
+<% else %>
+  <% node['logstash']['server']['inputs'].each do |input| -%>
+    <% input.each do |name,hash| -%>
+      <%= name %> {
+        <% hash.each do |k,v| -%>
+          <% case v -%>
+          <% when Array then -%>
+          <%= k %> => [ <%= v.map{|s| "\"#{s}\"" }.join(',') -%> ]
+          <% when TrueClass, FalseClass, Fixnum then -%>
+          <%= k %> => <%= v %>
+          <% else -%>
+          <%= k %> => '<%= v %>'
+          <% end # case -%>
+        <% end # each hash -%>
+      }
+    <% end # each name, hash -%>
+  <% end # each input -%>
+<% end # if -%>
 }
 
-<% unless  node['logstash']['server']['filters'].empty? -%>
+<% unless node['logstash']['server']['filters'].empty? -%>
 filter {
-   <% node['logstash']['server']['filters'].each do |filter| -%>
-      <% filter.each do |name,hash| -%> 
-         <%= name %> {
-           <% hash.each do |k,v| -%>         
-             <%= k %> => '<%= v %>'
-           <% end -%>
-      <% end -%>
-              }
-   <% end -%>
+  <% node['logstash']['server']['filters'].each do |filter| -%>
+    <% filter.each do |name,hash| -%>
+      <%= name %> {
+        <% hash.each do |k,v| -%>
+          <% case v -%>
+          <% when Array then -%>
+          <%= k %> => [ <%= v.map{|s| "\"#{s}\"" }.join(',') -%> ]
+          <% when TrueClass, FalseClass, Fixnum then -%>
+          <%= k %> => <%= v %>
+          <% else -%>
+          <%= k %> => '<%= v %>'
+          <% end # case -%>
+        <% end # each hash -%>
+      }
+    <% end # each name, hash -%>
+  <% end # each filter -%>
 }
-<% end -%>
-
+<% end # unless -%>
 
 output {
-	stdout { debug => true debug_format => "json" }
-	<% if @enable_embedded_es -%>
-	elasticsearch { embedded => true }
-	<% else -%>
-	elasticsearch { host => "<%= @es_server_ip %>" cluster => "<%= @es_cluster %>" }
-	<% end -%>
-	<% unless @graphite_server_ip.empty? -%>
-	graphite { host => "<%= @graphite_server_ip %>" metrics => ["logstash.events", "1"] }
-	<% end -%>
+  stdout { debug => true debug_format => "json" }
+<% if @enable_embedded_es -%>
+  elasticsearch { embedded => true }
+<% else -%>
+  elasticsearch { host => "<%= @es_server_ip %>" cluster => "<%= @es_cluster %>" }
+<% end -%>
+<% unless @graphite_server_ip.empty? -%>
+  graphite { host => "<%= @graphite_server_ip %>" metrics => ["logstash.events", "1"] }
+<% end -%>
 
-  <% unless  node['logstash']['server']['outputs'].empty? -%>
-      <% node['logstash']['server']['outputs'].each do |output| -%>
-        <% output.each do |name,hash| -%> 
-             <%= name %> {
-                 <% hash.each do |k,v| -%>         
-                    <% case v.class.to_s -%>
-                    <% when "String" -%>
-                       <%= k %> => '<%= v %>'
-                    <% when "Array" -%>
-                       <%= k %> => <%= v.inspect %>
-                    <% when "Trueclass", "FalseClass", "Fixnum" -%>
-                       <%= k %> => <%= v %>                    
-                    <% end -%>
-                 <% end -%>
-                   }    
-        <% end -%>
-            
-      <% end -%>
-  <% end -%>
-
+<% unless  node['logstash']['server']['outputs'].empty? -%>
+  <% node['logstash']['server']['outputs'].each do |output| -%>
+    <% output.each do |name,hash| -%>
+      <%= name %> {
+        <% hash.each do |k,v| -%>
+          <% case v -%>
+          <% when Array then -%>
+          <%= k %> => [ <%= v.map{|s| "\"#{s}\"" }.join(',') -%> ]
+          <% when TrueClass, FalseClass, Fixnum then -%>
+          <%= k %> => <%= v %>
+          <% else -%>
+          <%= k %> => '<%= v %>'
+          <% end # case -%>
+        <% end # each hash-%>
+      }
+    <% end # each name, hash -%>
+  <% end # each output -%>
+<% end # unless -%>
 }


### PR DESCRIPTION
For example, I know have a logstash role of the following:

```
name 'logstash'

default_attributes(
  logstash: {
    graphite_role: "graphite",
    elasticsearch_role: "elasticsearch",
    server: {
      enable_embedded_es: true,
      inputs: [
        { tcp: { port: '514', type: 'syslog' }}
      ],
      filters: [
        { grok: {
            type: "syslog",
            pattern: [ '<%{POSINT:syslog_pri}>%{SYSLOGTIMESTAMP:syslog_timestamp} %{SYSLOGHOST:syslog_hostname} %{PROG:syslog_program}(?:\[%{POSINT:syslog_pid}\])?: %{GREEDYDATA:syslog_message}' ],
            add_field: [ "received_at", "%{@timestamp}",
                         "received_from", "%{@source_host}" ] }},
        { syslog_pri: {
            type: "syslog" }},
        { date: {
            type: "syslog",
            syslog_timestamp: [ "MMM  d HH:mm:ss", "MMM dd HH:mm:ss" ] }},
        { mutate: {
            type: "syslog",
            replace: [ "@source_host", "%{syslog_hostname}",
                       "@message", "%{syslog_message}" ] }},
        { mutate: {
            type: "syslog",
            remove: [ "syslog_hostname", "syslog_message", "syslog_timestamp" ] }}
      ]
    }
  }
)

run_list [
  "role[base]",
  "recipe[logstash::server]",
  "recipe[logstash::kibana]"
]
```
