### PR TITLE
agent and server config file generator improved

### DIFF
--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -16,3 +16,8 @@ default['logstash']['agent']['server_role'] = "logstash_server"
 
 # for use in case recipe used w/ chef-solo, default to self
 default['logstash']['agent']['server_ipaddress'] = ""
+
+default['logstash']['agent']['inputs'] = []
+default['logstash']['agent']['filters'] = []
+default['logstash']['agent']['outputs'] = []
+

--- a/libraries/logstash_conf.rb
+++ b/libraries/logstash_conf.rb
@@ -1,0 +1,50 @@
+
+class Erubis::RubyEvaluator::LogstashConf
+
+  private
+
+  def self.key_to_str(k)
+    case k.class.to_s
+    when "String"
+      return k
+    when "Fixnum", "Float"
+      return k.to_s
+    when "Regex"
+      return k.inspect
+    end
+    return k
+  end
+
+  def self.key_value_to_str(k, v)
+    case v.class.to_s
+    when "String", "Fixnum", "Float"
+      return key_to_str(k) + " => '" + v + "'"
+    when "Array", "Regex"
+      return key_to_str(k) + " => " + v.inspect
+    when "Hash", "Mash"
+      return key_to_str(k) + " => " + v.to_a.flatten.inspect
+    when "TrueClass", "FalseClass", "Fixnum"
+      return key_to_str(k) + " => " + v.to_s
+    end
+    return key_to_str(k)
+  end
+
+  public
+  
+  def self.section_to_str(section)
+    result = []
+    section.each do |output|
+      output.sort.each do |name, hash|
+        result << ''
+        result << '  ' + name.to_s + ' {'
+        hash.sort.each do |k,v|
+          result << '    ' + key_value_to_str(k, v)
+        end
+        result << '  }'
+      end
+    end
+    return result.join("\n")
+  end
+  
+end
+  

--- a/templates/default/agent.conf.erb
+++ b/templates/default/agent.conf.erb
@@ -2,7 +2,6 @@
 # by Chef
 # Manual changes will be lost
 input {
-
   <% if  node['logstash']['agent']['inputs'].empty? -%>
   file {
     type => "sample-logs"
@@ -11,45 +10,30 @@ input {
     debug => true
   }
   <% else %>    
-    <% node['logstash']['agent']['inputs'].each do |input| -%>
-     
-        <% input.each do |name,hash| -%> 
-             <%= name %> {
-                 <% hash.each do |k,v| -%>         
-                       <%= k %> => '<%= v %>'
-                 <% end -%>
-        <% end -%>
-        }
-     <% end -%>
+    <%= LogstashConf.section_to_str(node['logstash']['agent']['inputs']) %>
   <% end -%>
-
 }
 
+<% unless node['logstash']['agent']['filters'].empty? -%>
+filter {
+  <%= LogstashConf.section_to_str(node['logstash']['agent']['filters']) %>
+}
+<% end -%>
+
 output {
+  <% if node['logstash']['agent']['debug'] -%>
   stdout { }
+  <% end -%>
   <% if @logstash_server_ip.empty? -%>
   # Provide a sane default
   null { }
   <% else -%>
-
     <% unless  node['logstash']['agent']['outputs'].empty? -%>
-      <% node['logstash']['agent']['outputs'].each do |output| -%>
-        <% output.each do |name,hash| -%> 
-           <%= name %> {
-           <% hash.each do |k,v| -%>         
-              <%= k %> => '<%= v %>'
-            <% end -%>
-        <% end -%>
-           }
-      <% end -%>
+      <%= LogstashConf.section_to_str(node['logstash']['agent']['outputs']) %>
     <% else -%> 
-  
-    tcp { host => "<%= @logstash_server_ip %>" port => "5959" }
 
+  tcp { host => "<%= @logstash_server_ip %>" port => "5959" }
     <% end -%>
-
-
   <% end -%>
 }
-
 

--- a/templates/default/server.conf.erb
+++ b/templates/default/server.conf.erb
@@ -1,68 +1,34 @@
 input {
-  <% if  node['logstash']['server']['inputs'].empty? -%>
+  <% if node['logstash']['server']['inputs'].empty? -%>
   tcp {
     type => "tcp-input"
     port => "5959"
     format => "json_event"
   }
-  <% else %>    
-    <% node['logstash']['server']['inputs'].each do |input| -%>
-     
-        <% input.each do |name,hash| -%> 
-             <%= name %> {
-                 <% hash.each do |k,v| -%>         
-                       <%= k %> => '<%= v %>'
-                 <% end -%>
-        <% end -%>
-        }
-     <% end -%>
+  <% else -%> 
+    <%= LogstashConf.section_to_str(node['logstash']['server']['inputs']) %>
   <% end -%>
 }
 
-<% unless  node['logstash']['server']['filters'].empty? -%>
+<% unless node['logstash']['server']['filters'].empty? -%>
 filter {
-   <% node['logstash']['server']['filters'].each do |filter| -%>
-      <% filter.each do |name,hash| -%> 
-         <%= name %> {
-           <% hash.each do |k,v| -%>         
-             <%= k %> => '<%= v %>'
-           <% end -%>
-      <% end -%>
-              }
-   <% end -%>
+  <%= LogstashConf.section_to_str(node['logstash']['server']['filters']) %>
 }
 <% end -%>
 
-
 output {
-	stdout { debug => true debug_format => "json" }
-	<% if @enable_embedded_es -%>
-	elasticsearch { embedded => true }
-	<% else -%>
-	elasticsearch { host => "<%= @es_server_ip %>" cluster => "<%= @es_cluster %>" }
-	<% end -%>
-	<% unless @graphite_server_ip.empty? -%>
-	graphite { host => "<%= @graphite_server_ip %>" metrics => ["logstash.events", "1"] }
-	<% end -%>
-
-  <% unless  node['logstash']['server']['outputs'].empty? -%>
-      <% node['logstash']['server']['outputs'].each do |output| -%>
-        <% output.each do |name,hash| -%> 
-             <%= name %> {
-                 <% hash.each do |k,v| -%>         
-                    <% case v.class.to_s -%>
-                    <% when "String" -%>
-                       <%= k %> => '<%= v %>'
-                    <% when "Array" -%>
-                       <%= k %> => <%= v.inspect %>
-                    <% when "Trueclass", "FalseClass", "Fixnum" -%>
-                       <%= k %> => <%= v %>                    
-                    <% end -%>
-                 <% end -%>
-                   }    
-        <% end -%>
-            
-      <% end -%>
+  <% if node['logstash']['server']['debug'] -%>
+  stdout { debug => true debug_format => "json" }
   <% end -%>
-
+  <% if @enable_embedded_es -%>
+  elasticsearch { embedded => true }
+  <% elsif not @es_server_ip.empty? -%>
+  elasticsearch { host => "<%= @es_server_ip %>" cluster => "<%= @es_cluster %>" }
+  <% end -%>
+  <% unless @graphite_server_ip.empty? -%>
+  graphite { host => "<%= @graphite_server_ip %>" metrics => ["logstash.events", "1"] }
+  <% end -%>
+  <% # unless node['logstash']['server']['outputs'].empty? -%>
+    <%= LogstashConf.section_to_str(node['logstash']['server']['outputs']) %>
+  <% # end -%>
 }


### PR DESCRIPTION
I propose the following changes to improve the generated configuration files:
- Some small fixes when using multiple plugins in filters/inputs sections (closing brace).
- Moved some logic to create the config file to a library (shared by agent and server).
- Stdout disabled by default: enabled in debug mode or, of course, putting the plugin in the output array.
