### PR TITLE
beaver restart on config changes and service reload marked as not supported

### DIFF
--- a/recipes/beaver.rb
+++ b/recipes/beaver.rb
@@ -81,6 +81,7 @@ template conf_file do
   variables(
             :files => files
   )
+  notifies :restart, "service[logstash_beaver]"
 end
 
 # outputs
@@ -139,7 +140,7 @@ template "/etc/init.d/logstash_beaver" do
   notifies :restart, "service[logstash_beaver]"
 end
 service "logstash_beaver" do
-  supports :restart => true, :reload => true, :status => true
+  supports :restart => true, :reload => false, :status => true
   action [:enable, :start]
 end
 


### PR DESCRIPTION
Two small fixes:
- Notify a beaver _:restart_ when the configuration file changes.
- Mark service _:reload_ as not supported for beaver.
