### PR TITLE
Added support for grok pattern files generation from node attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Attributes
 * `node['logstash']['elasticsearch_ip']` - the IP address that will be used for your elasticsearch server in case you are using Chef-solo
 * `node['logstash']['graphite_ip']` - the IP address that will be used for your graphite server in case you are using Chef-solo
 * `node['logstash']['join_groups']` - An array of Operative System groups to join. Usefull to gain read privileges on some logfiles.
+* `node['logstash']['patterns']` - A hash with grok patterns to be used on grok and multiline filters.
 
 
 ## Agent
@@ -52,6 +53,7 @@ Attributes
 * `node['logstash']['agent']['inputs']` - Array of input plugins configuration.
 * `node['logstash']['agent']['filters']` - Array of filter plugins configuration.
 * `node['logstash']['agent']['outputs']` - Array of output plugins configuration.
+* `node['logstash']['agent']['patterns_dir']` - The patterns directory where pattern files will be generated. Relative to the basedir or absolute.
 
 ## Server
 
@@ -72,6 +74,7 @@ Attributes
 * `node['logstash']['server']['inputs']` - Array of input plugins configuration.
 * `node['logstash']['server']['filters']` - Array of filter plugins configuration.
 * `node['logstash']['server']['outputs']` - Array of output plugins configuration.
+* `node['logstash']['server']['patterns_dir']` - The patterns directory where pattern files will be generated. Relative to the basedir or absolute.
 
 ## Kibana
 
@@ -292,6 +295,40 @@ It will produce the following logstash.conf file
 
     }
 
+
+## Adding grok patterns
+
+Grok pattern files can be generated using attributes as follows
+
+    default_attributes(
+      :logstash => {
+        :patterns => {
+          :apache => {
+            :HTTP_ERROR_DATE => '%{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{YEAR}',
+            :APACHE_LOG_LEVEL => '[A-Za-z][A-Za-z]+',
+            :ERRORAPACHELOG => '^\[%{HTTP_ERROR_DATE:timestamp}\] \[%{APACHE_LOG_LEVEL:level}\](?: \[client %{IPORHOST:clientip}\])?',
+          },
+          :mywebapp => {
+            :MYWEBAPP_LOG => '\[mywebapp\]',
+          },
+        },
+        [...]
+      }
+    )
+
+This will generate the following files:
+
+/opt/logstash/server/etc/patterns/apache
+
+    APACHE_LOG_LEVEL [A-Za-z][A-Za-z]+
+    ERRORAPACHELOG ^\[%{HTTP_ERROR_DATE:timestamp}\] \[%{APACHE_LOG_LEVEL:level}\](?: \[client %{IPORHOST:clientip}\])?
+    HTTP_ERROR_DATE %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{YEAR}
+
+/opt/logstash/server/etc/patterns/mywebapp
+
+    MYWEBAPP_LOG \[mywebapp\]
+
+This patterns will be included by default in the grok and multiline filters.
 
 
 # BIG WARNING

--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -2,6 +2,7 @@ default['logstash']['agent']['version'] = '1.1.1'
 default['logstash']['agent']['source_url'] = 'http://databits.net/petef/tmp/logstash-1.1.1-pre-monolithic-jruby1.7.0pre1.jar'
 default['logstash']['agent']['checksum'] = '6ca41718706c118ee6abb339bec9225b5d56cc3dc258d5053e64d00e24cdb918'
 default['logstash']['agent']['install_method'] = 'jar' # Either `source` or `jar`
+default['logstash']['agent']['patterns_dir'] = 'agent/etc/patterns'
 default['logstash']['agent']['base_config'] = 'agent.conf.erb'
 default['logstash']['agent']['base_config_cookbook'] = 'logstash'
 default['logstash']['agent']['xms'] = '384M'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,3 +11,5 @@ default['logstash']['elasticsearch_role'] = 'elasticsearch_server'
 default['logstash']['elasticsearch_cluster'] = 'logstash'
 default['logstash']['elasticsearch_ip'] = ''
 default['logstash']['graphite_ip'] = ''
+
+default['logstash']['patterns'] = []

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -2,6 +2,7 @@ default['logstash']['server']['version'] = '1.1.1'
 default['logstash']['server']['source_url'] = 'http://semicomplete.com/files/logstash/logstash-1.1.4-monolithic.jar'
 default['logstash']['server']['checksum'] = '5b8c3a2f92b807f0d88184576e08099d41b1eba9d858db12000ddda5bc440551'
 default['logstash']['server']['install_method'] = 'jar' # Either `source` or `jar`
+default['logstash']['server']['patterns_dir'] = 'server/etc/patterns'
 default['logstash']['server']['base_config'] = 'server.conf.erb'
 default['logstash']['server']['base_config_cookbook'] = 'logstash'
 default['logstash']['server']['xms'] = '1024M'

--- a/libraries/logstash_conf.rb
+++ b/libraries/logstash_conf.rb
@@ -1,4 +1,6 @@
 
+require 'rubygems'
+
 class Erubis::RubyEvaluator::LogstashConf
 
   private
@@ -31,12 +33,19 @@ class Erubis::RubyEvaluator::LogstashConf
 
   public
   
-  def self.section_to_str(section)
+  def self.section_to_str(section, version=nil, patterns_dir=nil)
     result = []
+    patterns_dir_plugins = [ 'grok' ]
+    unless version.nil?
+      patterns_dir_plugins << 'multiline' if Gem::Version.new(version) >= Gem::Version.new('1.1.2')
+    end
     section.each do |output|
       output.sort.each do |name, hash|
         result << ''
         result << '  ' + name.to_s + ' {'
+        if patterns_dir_plugins.include?(name.to_s) and not patterns_dir.nil? and not hash.has_key?('patterns_dir')
+          result << '    ' + key_value_to_str('patterns_dir', patterns_dir)
+        end
         hash.sort.each do |k,v|
           result << '    ' + key_value_to_str(k, v)
         end

--- a/templates/default/agent.conf.erb
+++ b/templates/default/agent.conf.erb
@@ -16,7 +16,7 @@ input {
 
 <% unless node['logstash']['agent']['filters'].empty? -%>
 filter {
-  <%= LogstashConf.section_to_str(node['logstash']['agent']['filters']) %>
+  <%= LogstashConf.section_to_str(node['logstash']['agent']['filters'], node['logstash']['agent']['version'], @patterns_dir) %>
 }
 <% end -%>
 

--- a/templates/default/patterns.erb
+++ b/templates/default/patterns.erb
@@ -1,0 +1,3 @@
+<% @patterns.sort.each do |name, pattern| -%>
+<%= name %> <%= pattern %>
+<% end -%>

--- a/templates/default/server.conf.erb
+++ b/templates/default/server.conf.erb
@@ -12,7 +12,7 @@ input {
 
 <% unless node['logstash']['server']['filters'].empty? -%>
 filter {
-  <%= LogstashConf.section_to_str(node['logstash']['server']['filters']) %>
+  <%= LogstashConf.section_to_str(node['logstash']['server']['filters'], node['logstash']['server']['version'], @patterns_dir) %>
 }
 <% end -%>
 


### PR DESCRIPTION
Saves pattern files by default in _/opt/logstash/(server|agent)/etc/patterns_, but this can be changed.

It works on both the servers and agents in the same way.
