### PR TITLE
Kibana PHP version updated to the lastest version

### DIFF
--- a/attributes/kibana.rb
+++ b/attributes/kibana.rb
@@ -1,5 +1,5 @@
 default['logstash']['kibana']['repo'] = 'git://github.com/rashidkpc/Kibana.git'
-default['logstash']['kibana']['sha'] = 'cfb13eaa4704fe4c9106bf9673123ce767d8afac'
+default['logstash']['kibana']['sha'] = '376676cf33e5a2ce932604e1159a00db0ad17dda'
 default['logstash']['kibana']['apache_template'] = 'kibana.conf.erb'
 default['logstash']['kibana']['config'] = 'kibana-config.php.erb'
 default['logstash']['kibana']['server_name'] = node['ipaddress']


### PR DESCRIPTION
This is the last commit on the Kibana PHP branch:

https://github.com/rashidkpc/Kibana/tree/php-deprecated
