### PR TITLE
Do not symlink the server

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -55,10 +55,6 @@ end
     owner node['logstash']['user']
     group node['logstash']['group']
   end
-
-  link "/var/lib/logstash/#{ldir}" do
-    to "#{node['logstash']['basedir']}/server/#{ldir}"
-  end
 end
 
 # installation


### PR DESCRIPTION
```
Before this change both the agent and server were symlinked to the
same directories: if both are installed on a node, this would
flip-flop between the two.
Since we have to choose, I decided to symlink the agent since the
server is arguably more "hands off" on most installations.
```

That's kind of arbitrary, you could also argue that some people may run pyshipper (and Jordan is working on yet another replacement), so maybe we should only symlink the server.

I don't care either way :) if you want to turn this around, fine with me.
