### PR TITLE
Don't depend on logstash, remove redundant name

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,11 +1,10 @@
+name             "logstash"
 maintainer       "John E. Vincent"
 maintainer_email "lusis.org+github.com@gmail.com"
 license          "Apache 2.0"
-name             "logstash"
 description      "Installs/Configures logstash"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.5.1"
-name             "logstash"
 
 supports         "ubuntu"
 supports         "debian"
@@ -26,4 +25,3 @@ depends "java"
 depends "ant"
 depends "logrotate"
 depends "rabbitmq"
-depends "logstash"


### PR DESCRIPTION
- Don't depend on logstash to prevent recursive dependency
- name attribute in metadata was redundant, move it to top too
