### PR TITLE
Fix patterns attribute default value

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,4 +12,4 @@ default['logstash']['elasticsearch_cluster'] = 'logstash'
 default['logstash']['elasticsearch_ip'] = ''
 default['logstash']['graphite_ip'] = ''
 
-default['logstash']['patterns'] = []
+default['logstash']['patterns'] = {}


### PR DESCRIPTION
An array as default value causes problems when merging attributes (e.g. in Chef solo).
