### PR TITLE
Adding support for installing beaver in ubuntu-10.04

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "lusis.org+github.com@gmail.com"
 license          "Apache 2.0"
 description      "Installs/Configures logstash"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.5.2"
+version          "0.5.3"
 
 supports         "ubuntu"
 supports         "debian"
@@ -25,3 +25,4 @@ depends "java"
 depends "ant"
 depends "logrotate"
 depends "rabbitmq"
+recommends "apt"

--- a/recipes/beaver.rb
+++ b/recipes/beaver.rb
@@ -6,8 +6,32 @@
 include_recipe "logstash::default"
 include_recipe "python::default"
 
+if platform?("ubuntu") && node['platform_version'].to_f == 10.04
+  apt_repository "lucid-zeromq-ppa" do
+    uri "http://ppa.launchpad.net/chris-lea/zeromq/ubuntu"
+    distribution "lucid"
+    components ["main"]
+    keyserver "keyserver.ubuntu.com"
+    key "C7917B12"
+    action :add
+    notifies :run, "execute[apt-get update]", :immediately
+  end
+
+  apt_repository "lucid-libpgm-ppa" do
+    uri "http://ppa.launchpad.net/chris-lea/libpgm/ubuntu"
+    distribution "lucid"
+    components ["main"]
+    keyserver "keyserver.ubuntu.com"
+    key "C7917B12"
+    action :add
+    notifies :run, "execute[apt-get update]", :immediately
+  end
+  package 'git-core'
+else
+  package 'git'
+end
+
 package 'libzmq-dev'
-package 'git'
 
 basedir = node['logstash']['basedir'] + '/beaver'
 


### PR DESCRIPTION
Required libs are not available in lucid's standard repo, so we're using a couple of PPAs here for ZeroMQ libs. Git package is also called git-core in lucid.
