### PR TITLE
beaver init.d script is_up function fixed

### DIFF
--- a/templates/default/init-beaver.erb
+++ b/templates/default/init-beaver.erb
@@ -72,7 +72,7 @@ beaver_pid() {
 
 is_up() {
     PID="$(beaver_pid)"
-    [ x"${PID}" != x ] && ps -p "${PID}" -o comm h 2> /dev/null | grep -qFw "${BEAVER_NAME}"
+    [ x"${PID}" != x ] && ps -p "${PID}" -o comm,args h 2> /dev/null | grep -qFw "${BEAVER_NAME}"
 }
 
 do_kill() {


### PR DESCRIPTION
In some systems beaver init.d _is_up(_) function doesn't work properly.
