### PR TITLE
Use sha256 checksums instead of md5.

### DIFF
--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -1,6 +1,6 @@
 default['logstash']['agent']['version'] = '1.1.9'
 default['logstash']['agent']['source_url'] = 'https://logstash.objects.dreamhost.com/release/logstash-1.1.9-monolithic.jar'
-default['logstash']['agent']['checksum'] = '70addd3ccd37e796f473fe5647c31126'
+default['logstash']['agent']['checksum'] = 'e444e89a90583a75c2d6539e5222e2803621baa0ae94cb77dbbcebacdc0c3fc7'
 default['logstash']['agent']['install_method'] = 'jar' # Either `source` or `jar`
 default['logstash']['agent']['patterns_dir'] = 'agent/etc/patterns'
 default['logstash']['agent']['base_config'] = 'agent.conf.erb'

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -1,6 +1,6 @@
 default['logstash']['server']['version'] = '1.1.9'
 default['logstash']['server']['source_url'] = 'https://logstash.objects.dreamhost.com/release/logstash-1.1.9-monolithic.jar'
-default['logstash']['server']['checksum'] = '70addd3ccd37e796f473fe5647c31126'
+default['logstash']['server']['checksum'] = 'e444e89a90583a75c2d6539e5222e2803621baa0ae94cb77dbbcebacdc0c3fc7'
 default['logstash']['server']['install_method'] = 'jar' # Either `source` or `jar`
 default['logstash']['server']['patterns_dir'] = 'server/etc/patterns'
 default['logstash']['server']['base_config'] = 'server.conf.erb'


### PR DESCRIPTION
Chef only supports sha256 checksums for `remote_file` right now.
