### PR TITLE
add heap size variables to the agent recipe's init template resource.

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -91,7 +91,9 @@ elsif platform_family? "rhel", "fedora"
     mode "0774"
     variables(
       :config_file => "shipper.conf",
-      :name => 'agent'
+      :name => 'agent',
+      :max_heap => node['logstash']['agent']['xmx'],
+      :min_heap => node['logstash']['agent']['xms']
     )
   end
 


### PR DESCRIPTION
Bryan's recent heap size change got added to the init template resourece in the server recipe, but not to the agent, causing the init script to silently fail when starting up logstash agent on a redhat system.  This just adds the variables he had set in the agent attributes to the template resource. 

Tested on RHEL 6.3
