### PR TITLE
Add a cd to LS_HOME to the init template.

### DIFF
--- a/templates/default/init.erb
+++ b/templates/default/init.erb
@@ -47,6 +47,7 @@ start() {
   fi
 
   echo -e "\033[1mStarting logstash...\033[0m"
+  cd $LS_HOME
   su $LS_USER -c "$BIN_SCRIPT" & > /dev/null 2>&1
   ls_pid=$!
   result=$?


### PR DESCRIPTION
Logstash's embedded elastic search looks for it's data directory under the current working directory when it is started.  Without a cd, this would be the root directory, and the server would fail to start when it could not create /data/elasticsearch.   Note, since they share the init template this change will also affect agent initialization, but that shouldn't cause problems.
