### PR TITLE
Quote keys in the generated logstash.conf

### DIFF
--- a/libraries/logstash_conf.rb
+++ b/libraries/logstash_conf.rb
@@ -8,7 +8,7 @@ class Erubis::RubyEvaluator::LogstashConf
   def self.key_to_str(k)
     case k.class.to_s
     when "String"
-      return k
+      return "'#{k}'"
     when "Fixnum", "Float"
       return k.to_s
     when "Regex"


### PR DESCRIPTION
Certain field names are not allowed unquoted in the logstash config. As an example, this `json` filter definition produces an error during startup:

```
json {
  @message => 'json_data'
  type => 'syslog'
}
```

The error message is:

```
Error at line 70, column 5: "@message => 'json_data'\n    type => 'syslog'\n  }\n\n"
```

This patch quotes the key names in the generated logstash config which allows logstash to parse the config and evaluate the filter as intended.
