### PR TITLE
Use https rubygems for more winning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gem 'berkshelf'
 gem 'vagrant', '~> 1.0.5'


### PR DESCRIPTION
Being pedantic, I know.

Recent versions of bundler will default to https for :rubygems (see https://github.com/carlhuda/bundler/pull/2315/files, merged 2/14/2013), but it probably won't hurt to be specific.
