### PR TITLE
On ubuntu systems the platform_family is debian

### DIFF
--- a/recipes/beaver.rb
+++ b/recipes/beaver.rb
@@ -177,7 +177,7 @@ when "fedora"
   if node['platform_version'].to_i >= 9
     use_upstart = true
   end
-when "ubuntu"
+when "debian"
   use_upstart = true
   if node['platform_version'].to_f >= 12.04
     supports_setuid = true


### PR DESCRIPTION
On our Ubuntu nodes platform_family is assigned a value of "debian" while platform is set to "ubuntu". However I think the intent of this when block is to match ubuntu systems.
