### PR TITLE
Move service definition after template is put in place

### DIFF
--- a/recipes/beaver.rb
+++ b/recipes/beaver.rb
@@ -204,11 +204,6 @@ if use_upstart
     provider Chef::Provider::Service::Upstart
   end
 else
-  service "logstash_beaver" do
-    supports :restart => true, :reload => false, :status => true
-    action [:enable, :start]
-  end
-
   template "/etc/init.d/logstash_beaver" do
     mode "0755"
     source "init-beaver.erb"
@@ -220,6 +215,11 @@ else
               :platform => node['platform']
               )
     notifies :restart, "service[logstash_beaver]"
+  end
+
+  service "logstash_beaver" do
+    supports :restart => true, :reload => false, :status => true
+    action [:enable, :start]
   end
 end
 


### PR DESCRIPTION
The service block fails on initial run if the init.d file is not already in place. Swapping the order of these operations seems to fix things.
