### PR TITLE
fixes for chef 11 warning

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,9 +19,9 @@ default['logstash']['graphite_ip'] = ''
 default['logstash']['patterns'] = {}
 default['logstash']['install_zeromq'] = false
 
-case
-when platform_family?("rhel")
-  node.set['logstash']['zeromq_packages'] = [ "zeromq",  "zeromq-devel"]
-when platform_family?("debian")
-  node.set['logstash']['zeromq_packages'] = [ "zeromq",  "libzmq-dev"]
+case node['platform_family']
+when "rhel"
+  default['logstash']['zeromq_packages'] = [ "zeromq",  "zeromq-devel"]
+when "debian"
+  default['logstash']['zeromq_packages'] = [ "zeromq",  "libzmq-dev"]
 end


### PR DESCRIPTION
when using platform family in attributes, you need to call:

node['platform_family']

otherwise you get handled by the missing_method handler. Also, this
sets default instead of the value on the node for libzmq

(This is take two. Somehow, the first pull request got hosed. Well, by somehow, I mean I must have done something stupid)
