### PR TITLE
Upgrade to 1.1.10, and move to flatjar

### DIFF
--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -1,6 +1,6 @@
-default['logstash']['agent']['version'] = '1.1.9'
-default['logstash']['agent']['source_url'] = 'https://logstash.objects.dreamhost.com/release/logstash-1.1.9-monolithic.jar'
-default['logstash']['agent']['checksum'] = 'e444e89a90583a75c2d6539e5222e2803621baa0ae94cb77dbbcebacdc0c3fc7'
+default['logstash']['agent']['version'] = '1.1.10'                             
+default['logstash']['agent']['source_url'] = 'https://logstash.objects.dreamhost.com/release/logstash-1.1.10-flatjar.jar'
+default['logstash']['agent']['checksum'] = 'c417e73ce136adb00fd9ace75b705c3ee353d8bb4f31e81ba121ce4955f2c32d'
 default['logstash']['agent']['install_method'] = 'jar' # Either `source` or `jar`
 default['logstash']['agent']['patterns_dir'] = 'agent/etc/patterns'
 default['logstash']['agent']['base_config'] = 'agent.conf.erb'

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -1,6 +1,6 @@
-default['logstash']['server']['version'] = '1.1.9'
-default['logstash']['server']['source_url'] = 'https://logstash.objects.dreamhost.com/release/logstash-1.1.9-monolithic.jar'
-default['logstash']['server']['checksum'] = 'e444e89a90583a75c2d6539e5222e2803621baa0ae94cb77dbbcebacdc0c3fc7'
+default['logstash']['server']['version'] = '1.1.10'
+default['logstash']['server']['source_url'] = 'https://logstash.objects.dreamhost.com/release/logstash-1.1.10-flatjar.jar'
+default['logstash']['server']['checksum'] = 'c417e73ce136adb00fd9ace75b705c3ee353d8bb4f31e81ba121ce4955f2c32d'
 default['logstash']['server']['install_method'] = 'jar' # Either `source` or `jar`
 default['logstash']['server']['patterns_dir'] = 'server/etc/patterns'
 default['logstash']['server']['base_config'] = 'server.conf.erb'


### PR DESCRIPTION
Quick and simple, brings logstash up to version 1.1.10.  This also migrates from monolithic to flatjar, which doesn't change behaviour that I'm aware of other than speeding up startup time.
