### PR TITLE
Only include NameVirtualHost entry for kibana if it is not already defined by apache

### DIFF
--- a/templates/default/kibana.conf.erb
+++ b/templates/default/kibana.conf.erb
@@ -1,4 +1,6 @@
+<% unless node['apache']['listen_ports'].include?(node['logstash']['kibana']['http_port']) %>
 NameVirtualHost *:<%= node['logstash']['kibana']['http_port'] %>
+<% end %>
 <VirtualHost *:<%= node['logstash']['kibana']['http_port'] %>>
   ServerName <%= @server_name %>
   DocumentRoot "<%= @docroot %>"


### PR DESCRIPTION
Cleans up warnings when restarting apache when node['logstash']['kibana']['http_port'] is a commonly used port defined in apache's ports.conf.
