### PR TITLE
Add missing options to logrotate. Without copytruncate logstash will con...

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -173,7 +173,7 @@ logrotate_app "logstash_server" do
   path "#{node['logstash']['log_dir']}/*.log"
   frequency "daily"
   rotate "30"
-  options [ "missingok", "notifempty" ]
+  options [ "missingok", "notifempty", "compress", "copytruncate" ]
   create "664 #{node['logstash']['user']} #{node['logstash']['group']}"
 end
 


### PR DESCRIPTION
...tinue to write to the rotated log file. I think the intent of commit e938865d36d5f49c81b098247e11579a9f8be408 was only to remove delaycompress rather than remove compression altogether.
