### PR TITLE
Use sudo -u with Upstart managed agents

### DIFF
--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -11,6 +11,7 @@ default['logstash']['agent']['java_opts'] = ''
 default['logstash']['agent']['gc_opts'] = '-XX:+UseParallelOldGC'
 default['logstash']['agent']['ipv4_only'] = false
 default['logstash']['agent']['debug'] = false
+default['logstash']['agent']['upstart_with_sudo'] = false
 
 # roles/flasgs for various autoconfig/discovery components
 default['logstash']['agent']['server_role'] = 'logstash_server'

--- a/templates/default/logstash_agent.conf.erb
+++ b/templates/default/logstash_agent.conf.erb
@@ -8,8 +8,9 @@ respawn
 respawn limit 5 30
 
 chdir <%= node['logstash']['basedir'] %>/agent
+<% if node['logstash']['agent']['upstart_with_sudo'] == false -%>
 setuid <%= node['logstash']['user'] %>
-setgid <%= node['logstash']['group'] %>
+<% end -%>
 
 script
   export LOGSTASH_HOME="<%= node['logstash']['basedir'] %>/agent"
@@ -22,7 +23,11 @@ script
   <% end -%>
   export OPTS="$JAVA_OPTS $GC_OPTS -jar $LOGSTASH_HOME/lib/logstash.jar $LOGSTASH_OPTS"
 
+  <% if node['logstash']['agent']['upstart_with_sudo'] -%>
+  exec sudo -u <%= node['logstash']['user'] %> /usr/bin/java $OPTS
+  <% else -%>
   exec /usr/bin/java $OPTS
+  <% end -%>
 end script
 
 emits logstash-agent-running


### PR DESCRIPTION
Added the ability to use sudo to start the Upstart managed agent, so that node['logstash']['join_groups'] works as expected under Upstart
