### PR TITLE
allow runit even on 12.04 and also in kibana

### DIFF
--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -12,6 +12,7 @@ default['logstash']['agent']['gc_opts'] = '-XX:+UseParallelOldGC'
 default['logstash']['agent']['ipv4_only'] = false
 default['logstash']['agent']['debug'] = false
 default['logstash']['agent']['upstart_with_sudo'] = false
+default['logstash']['agent']['init_method'] = 'native' # runit or native
 
 # logrotate options for logstash agent
 default['logstash']['agent']['logrotate']['options'] = [ "missingok", "notifempty" ]

--- a/attributes/kibana.rb
+++ b/attributes/kibana.rb
@@ -16,6 +16,7 @@ default['logstash']['kibana']['auth']['cas_login_url'] = "https://example.com/ca
 default['logstash']['kibana']['auth']['cas_validate_url'] = "https://example.com/cas/serviceValidate"
 default['logstash']['kibana']['auth']['cas_validate_server'] = "off"
 default['logstash']['kibana']['auth']['cas_root_proxy_url'] = nil
+default['logstash']['kibana']['init_method'] = 'native' # native or runit. Only applies to Ruby Kibana
 default['apache']['default_site_enabled'] = false
 
 #Smart_index_pattern = 'logstash-%Y.%m.%d'

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -13,6 +13,7 @@ default['logstash']['server']['ipv4_only'] = false
 default['logstash']['server']['debug'] = false
 default['logstash']['server']['home'] = '/opt/logstash/server'
 default['logstash']['server']['install_rabbitmq'] = true
+default['logstash']['server']['init_method'] = "native" # native or runit
 
 # roles/flags for various autoconfig/discovery components
 default['logstash']['server']['enable_embedded_es'] = true

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -19,6 +19,12 @@ if node['logstash']['install_zeromq']
   node['logstash']['zeromq_packages'].each {|p| package p }
 end
 
+if node['logstash']['server']['init_method'] == 'runit'
+  service_resource = 'runit_service[logstash_server]'
+else
+  service_resource = 'service[logstash_server]'
+end
+
 if node['logstash']['server']['patterns_dir'][0] == '/'
   patterns_dir = node['logstash']['server']['patterns_dir']
 else
@@ -44,6 +50,9 @@ else
     graphite_server_ip = node['logstash']['graphite_ip']
   end
 end
+
+Chef::Log.info("ElasticSearch server is: #{es_server_ip}")
+Chef::Log.info("Graphite server is: #{graphite_server_ip}")
 
 # Create directory for logstash
 directory "#{node['logstash']['basedir']}/server" do
@@ -75,7 +84,7 @@ if node['logstash']['server']['install_method'] == "jar"
 
   link "#{node['logstash']['basedir']}/server/lib/logstash.jar" do
     to "#{node['logstash']['basedir']}/server/lib/logstash-#{node['logstash']['server']['version']}.jar"
-    notifies :restart, "service[logstash_server]"
+    notifies :restart, service_resource
   end
 else
   include_recipe "logstash::source"
@@ -83,7 +92,7 @@ else
   logstash_version = node['logstash']['source']['sha'] || "v#{node['logstash']['server']['version']}"
   link "#{node['logstash']['basedir']}/server/lib/logstash.jar" do
     to "#{node['logstash']['basedir']}/source/build/logstash-#{logstash_version}-monolithic.jar"
-    notifies :restart, "service[logstash_server]"
+    notifies :restart, service_resource
   end
 end
 
@@ -101,6 +110,14 @@ directory patterns_dir do
   group node['logstash']['group']
 end
 
+directory node['logstash']['log_dir'] do
+  action :create
+  mode "0755"
+  owner node['logstash']['user']
+  group node['logstash']['group']
+  recursive true
+end
+
 node['logstash']['patterns'].each do |file, hash|
   template_name = patterns_dir + '/' + file
   template template_name do
@@ -109,7 +126,7 @@ node['logstash']['patterns'].each do |file, hash|
     group node['logstash']['group']
     variables(:patterns => hash)
     mode '0644'
-    notifies :restart, 'service[logstash_server]'
+    notifies :restart, service_resource
   end
 end
 
@@ -124,49 +141,47 @@ template "#{node['logstash']['basedir']}/server/etc/logstash.conf" do
             :enable_embedded_es => node['logstash']['server']['enable_embedded_es'],
             :es_cluster => node['logstash']['elasticsearch_cluster'],
             :patterns_dir => patterns_dir)
-  notifies :restart, "service[logstash_server]"
+  notifies :restart, service_resource
   action :create
 end
 
-if platform_family? "debian"
-  if node["platform_version"] == "12.04"
-    template "/etc/init/logstash_server.conf" do
-      mode "0644"
-      source "logstash_server.conf.erb"
+if node['logstash']['server']['init_method'] == 'runit'
+  runit_service "logstash_server"
+elsif node['logstash']['server']['init_method'] == 'native'
+  if platform_family? "debian"
+    if node["platform_version"] == "12.04"
+      template "/etc/init/logstash_server.conf" do
+        mode "0644"
+        source "logstash_server.conf.erb"
+      end
+
+      service "logstash_server" do
+        provider Chef::Provider::Service::Upstart
+        action [ :enable, :start ]
+      end
+    else
+      runit_service "logstash_server"
+    end
+  elsif platform_family? "rhel","fedora"
+    template "/etc/init.d/logstash_server" do
+      source "init.erb"
+      owner "root"
+      group "root"
+      mode "0774"
+      variables(:config_file => "logstash.conf",
+                :name => 'server',
+                :max_heap => node['logstash']['server']['xmx'],
+                :min_heap => node['logstash']['server']['xms']
+                )
     end
 
     service "logstash_server" do
-      provider Chef::Provider::Service::Upstart
-      action [ :enable, :start ]
+      supports :restart => true, :reload => true, :status => true
+      action [:enable, :start]
     end
-  else
-    runit_service "logstash_server"
   end
-elsif platform_family? "rhel","fedora"
-  template "/etc/init.d/logstash_server" do
-    source "init.erb"
-    owner "root"
-    group "root"
-    mode "0774"
-    variables(:config_file => "logstash.conf",
-              :name => 'server',
-              :max_heap => node['logstash']['server']['xmx'],
-              :min_heap => node['logstash']['server']['xms']
-              )
-  end
-
-  service "logstash_server" do
-    supports :restart => true, :reload => true, :status => true
-    action [:enable, :start]
-  end
-end
-
-directory node['logstash']['log_dir'] do
-  action :create
-  mode "0755"
-  owner node['logstash']['user']
-  group node['logstash']['group']
-  recursive true
+else
+  Chef::Log.fatal("Unsupported init method: #{node['logstash']['server']['init_method']}")
 end
 
 logrotate_app "logstash_server" do

--- a/templates/default/sv-kibana-log-run.erb
+++ b/templates/default/sv-kibana-log-run.erb
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec svlogd -tt ./main

--- a/templates/default/sv-kibana-run.erb
+++ b/templates/default/sv-kibana-run.erb
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cd <%= @options[:kibana_home] %>
+exec 2>&1
+KIBANA_HOME="<%= @options[:kibana_home] %>"
+exec chpst -u<%= @options[:user] %> -e /etc/sv/kibana/env/ /opt/rbenv/shims/bundle exec ruby kibana.rb


### PR DESCRIPTION
Some changes (backwards compat) for the init part of various services. Basically I don't want to ever use upstart if I can help it. I'd rather use runit everywhere. This PR gives the option of using runit in kibana and server. Agent will need to be added as well.
