### PR TITLE
allow control of the upstart respawn count/timeout for the agent

### DIFF
--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -11,13 +11,15 @@ default['logstash']['agent']['java_opts'] = ''
 default['logstash']['agent']['gc_opts'] = '-XX:+UseParallelOldGC'
 default['logstash']['agent']['ipv4_only'] = false
 default['logstash']['agent']['debug'] = false
+# allow control over the upstart config
 default['logstash']['agent']['upstart_with_sudo'] = false
+default['logstash']['agent']['upstart_respawn_count'] = 5
+default['logstash']['agent']['upstart_respawn_timeout'] = 30
 
 # logrotate options for logstash agent
 default['logstash']['agent']['logrotate']['options'] = [ "missingok", "notifempty" ]
 # stop/start on logrotate?
 default['logstash']['agent']['logrotate']['stopstartprepost'] = false
-
 
 # roles/flasgs for various autoconfig/discovery components
 default['logstash']['agent']['server_role'] = 'logstash_server'

--- a/templates/default/logstash_agent.conf.erb
+++ b/templates/default/logstash_agent.conf.erb
@@ -5,7 +5,8 @@ start on (filesystem and net-device-up)
 stop on runlevel [!2345]
 
 respawn
-respawn limit 5 30
+respawn limit <%=node['logstash']['agent']['upstart_respawn_count']%> <%=node['logstash']['agent']['upstart_respawn_timeout']%>
+
 
 chdir <%= node['logstash']['basedir'] %>/agent
 <% if node['logstash']['agent']['upstart_with_sudo'] == false -%>


### PR DESCRIPTION
the default "5 30" for an agent was a little too optimistic for some of our nodes, so we were missing some agents spinning, this is to allow us to tweak the timeframe.

http://upstart.ubuntu.com/wiki/Stanzas#respawn 
