### PR TITLE
Cannot create htpasswd

### DIFF
--- a/recipes/kibana.rb
+++ b/recipes/kibana.rb
@@ -149,7 +149,7 @@ when "ruby"
       htpasswd_password = node['logstash']['kibana']['auth']['password']
 
       execute "add htpasswd file" do
-        command "/usr/bin/htpasswd -b #{htpasswd_path} #{htpasswd_user} #{htpasswd_password}"
+        command "/usr/bin/htpasswd -cb #{htpasswd_path} #{htpasswd_user} #{htpasswd_password}"
       end
   
       file htpasswd_path do
@@ -241,7 +241,7 @@ when "php"
     end
 
     execute "add htpasswd file" do
-      command "/usr/bin/htpasswd -b #{htpasswd_path} #{htpasswd_user} #{htpasswd_password}"
+      command "/usr/bin/htpasswd -cb #{htpasswd_path} #{htpasswd_user} #{htpasswd_password}"
     end
   end
   service "apache2"


### PR DESCRIPTION
This was happening on Ubuntu 12.10, and is probably happening everywhere.
