### PR TITLE
Fix typo in server init_method warning message

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -158,7 +158,7 @@ elsif node['logstash']['server']['init_method'] == 'native'
         action [ :enable, :start ]
       end
     else
-      Chef::Log.fatal("Please set node['logstash']['agent']['init_method'] to 'runit' for #{node['platform_version']}")
+      Chef::Log.fatal("Please set node['logstash']['server']['init_method'] to 'runit' for #{node['platform_version']}")
     end
   elsif platform_family? "rhel","fedora"
     template "/etc/init.d/logstash_server" do


### PR DESCRIPTION
When using init_method = 'native' in server it was throwing a message about setting the correct "agent" init_method instead of the "server" init_method
