### PR TITLE
remove sort of config hash to retain order

### DIFF
--- a/libraries/logstash_conf.rb
+++ b/libraries/logstash_conf.rb
@@ -49,7 +49,7 @@ class Erubis::RubyEvaluator::LogstashConf
       patterns_dir_plugins << 'multiline' if Gem::Version.new(version) >= Gem::Version.new('1.1.2')
     end
     section.each do |output|
-      output.sort.each do |name, hash|
+      output.each do |name, hash|
         result << ''
         result << '  ' + name.to_s + ' {'
         if patterns_dir_plugins.include?(name.to_s) and not patterns_dir.nil? and not hash.has_key?('patterns_dir')


### PR DESCRIPTION
leave config file in order the hash is written in.    this helps chain up filters in order with tags. 
