### PR TITLE
move include java to agent/server from default to avoid unnecessary installs

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -3,6 +3,7 @@
 # Recipe:: agent
 #
 #
+include_recipe "java"
 include_recipe "logstash::default"
 
 if node['logstash']['agent']['init_method'] == 'runit'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,7 +3,6 @@
 # Recipe:: default
 #
 include_recipe "runit" unless node["platform_version"] >= "12.04"
-include_recipe "java"
 
 if node['logstash']['create_account']
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -9,6 +9,7 @@
 #
 #
 
+include_recipe "java"
 include_recipe "logstash::default"
 include_recipe "logrotate"
 


### PR DESCRIPTION
If include java is in the default when logstash::beaver is included it unnecessarily installs java.
This ensures it's only installed with the agent and server
