### PR TITLE
Send SIGHUP to logstash after log rotation.

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -189,5 +189,8 @@ logrotate_app "logstash_server" do
   rotate "30"
   options node['logstash']['server']['logrotate']['options']
   create "664 #{node['logstash']['user']} #{node['logstash']['group']}"
+  postrotate <<-SCRIPT
+    kill -s 1 `ps -eo pid,cmd | grep -E 'java .*logstash.jar' | grep -v grep | awk '{ print $1 }'` || true
+  SCRIPT
 end
 


### PR DESCRIPTION
Logstash now reopens its log file on SIGHUP, starting in version [1.2.0](https://github.com/logstash/logstash/blob/46e5b75c3f821d3a2f4834312b1e75ab3ebcf3cb/CHANGELOG#L35).

I have confirmed, and it's safe to send a SIGHUP to older versions of LogStash as well (tested on 1.1.13).
