### PR TITLE
Restart service when config changes

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -152,6 +152,7 @@ elsif node['logstash']['server']['init_method'] == 'native'
       template "/etc/init/logstash_server.conf" do
         mode "0644"
         source "logstash_server.conf.erb"
+        notifies :restart, service_resource
       end
 
       service "logstash_server" do


### PR DESCRIPTION
Changes to attributes that apply to the init template are not applied since there is never a restart. This will restart the service to apply changes.
