### PR TITLE
Fix 0.7.0 Upstart job setgid

### DIFF
--- a/templates/default/logstash_server.conf.erb
+++ b/templates/default/logstash_server.conf.erb
@@ -11,7 +11,7 @@ limit nofile 65550 65550
 chdir <%= node['logstash']['server']['home'] %>
 setuid <%= node['logstash']['user'] %>
 
-<% if node['logstash']['supervisor_gid'] -%>
+<% if node['logstash']['supervisor_gid'] && !node['logstash']['supervisor_gid'].empty? -%>
 setgid <%= node['logstash']['supervisor_gid'] %>
 <% end -%>
 


### PR DESCRIPTION
Don't output empty setgid line if supervisor_gid is present, but empty
