### PR TITLE
systemd support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,8 @@
 default['logstash']['basedir'] = '/opt/logstash'
 default['logstash']['user'] = 'logstash'
+default['logstash']['uid'] = nil  # set to nil to let system pick
 default['logstash']['group'] = 'logstash'
+default['logstash']['gid'] = nil  # set to nil to let system pick
 default['logstash']['supervisor_gid'] = '' # set this if you want all logstash processes to run as different gid,  can be overridden
 default['logstash']['pid_dir'] = '/var/run/logstash'
 default['logstash']['create_account'] = true

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -1,6 +1,6 @@
 default['logstash']['server']['version'] = '1.2.2'
 default['logstash']['server']['home'] = "#{node['logstash']['basedir']}/server"
-default['logstash']['server']['log_file'] = '/var/log/logstash/server.log'
+default['logstash']['server']['log_file'] = '/var/log/logstash/server.log' # set blank to log to stdout
 default['logstash']['server']['source_url'] = 'https://download.elasticsearch.org/logstash/logstash/logstash-1.2.2-flatjar.jar'
 default['logstash']['server']['checksum'] = '6b0974eed6814f479b68259b690e8c27ecbca2817b708c8ef2a11ce082b1183c'
 default['logstash']['server']['install_method'] = 'jar' # Either `source` or `jar`

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,6 +8,7 @@ if node['logstash']['create_account']
 
   group node['logstash']['group'] do
     system true
+    gid node['logstash']['gid']
   end
 
   user node['logstash']['user'] do
@@ -16,6 +17,7 @@ if node['logstash']['create_account']
     system true
     action :create
     manage_home true
+    uid node['logstash']['uid']
   end
 
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -183,6 +183,24 @@ elsif node['logstash']['server']['init_method'] == 'native'
     else
       Chef::Log.fatal("Please set node['logstash']['server']['init_method'] to 'runit' for #{node['platform_version']}")
     end
+  elsif platform_family? "fedora" and node["platform_version"] >= "15"
+    execute "reload-systemd" do
+      command "systemctl --system daemon-reload"
+      action :nothing
+    end
+
+    template "/etc/systemd/system/logstash_server.service" do
+      source "logstash_server.service.erb"
+      owner "root" and group 'root' and mode 0755
+      notifies :run, "execute[reload-systemd]", :immediately
+      notifies :restart, "service[logstash_server]", :delayed
+    end
+
+    service "logstash_server" do
+      service_name "logstash_server.service"
+      provider Chef::Provider::Service::Systemd
+      action [ :enable, :start ]
+    end
   elsif platform_family? "rhel","fedora"
     template "/etc/init.d/logstash_server" do
       source "init.erb"

--- a/templates/default/logstash_server.conf.erb
+++ b/templates/default/logstash_server.conf.erb
@@ -22,9 +22,12 @@ script
   export HOME=$LOGSTASH_HOME
   export GC_OPTS="<%= node['logstash']['server']['gc_opts'] %>"
   export JAVA_OPTS="-server -Xms<%= node['logstash']['server']['xms'] %> -Xmx<%= node['logstash']['server']['xmx'] %> -Djava.io.tmpdir=$LOGSTASH_HOME/tmp/ <%= node['logstash']['server']['java_opts'] %> <%= '-Djava.net.preferIPv4Stack=true' if node['logstash']['agent']['ipv4_only'] %>"
-  export LOGSTASH_OPTS="agent -f <%= node['logstash']['server']['config_dir'] %> -l <%= node['logstash']['server']['log_file'] %>"
+  export LOGSTASH_OPTS="agent -f <%= node['logstash']['server']['config_dir'] %>"
   <% if node['logstash']['server']['pluginpath'] -%>
   export LOGSTASH_OPTS="$LOGSTASH_OPTS --pluginpath <%= node['logstash']['server']['pluginpath'] %>"
+  <% end -%>
+  <% unless node['logstash']['server']['log_file'] == '' -%>
+  export LOGSTASH_OPTS="$LOGSTASH_OPTS -l <%= node['logstash']['server']['log_file'] %>"
   <% end -%>
   <% if node['logstash']['server']['debug'] -%>
   export LOGSTASH_OPTS="$LOGSTASH_OPTS -vv"

--- a/templates/default/sv-logstash_server-run.erb
+++ b/templates/default/sv-logstash_server-run.erb
@@ -9,11 +9,14 @@ exec 2>&1
 LOGSTASH_HOME="<%= node['logstash']['server']['home'] %>"
 GC_OPTS="<%= node['logstash']['server']['gc_opts'] %>"
 JAVA_OPTS="-server -Xms<%= node['logstash']['server']['xms'] %> -Xmx<%= node['logstash']['server']['xmx'] %> -Djava.io.tmpdir=$LOGSTASH_HOME/tmp/ <%= node['logstash']['server']['java_opts'] %> <%= '-Djava.net.preferIPv4Stack=true' if node['logstash']['agent']['ipv4_only'] %>"
-LOGSTASH_OPTS="agent -f <%= node['logstash']['server']['config_dir'] %> -l <%= node['logstash']['server']['log_file'] %>"
+LOGSTASH_OPTS="agent -f <%= node['logstash']['server']['config_dir'] %>"
 <% if node['logstash']['server']['pluginpath'] -%>
 LOGSTASH_OPTS="$LOGSTASH_OPTS --pluginpath <%= node['logstash']['server']['pluginpath'] %>"
 <% end -%>
-<% if node['logstash']['agent']['debug'] -%>
+<% unless node['logstash']['server']['log_file'] == '' -%>
+LOGSTASH_OPTS="$LOGSTASH_OPTS -l <%= node['logstash']['server']['log_file'] %>"
+<% end -%>
+<% if node['logstash']['server']['debug'] -%>
 LOGSTASH_OPTS="$LOGSTASH_OPTS -v"
 <% end -%>
 


### PR DESCRIPTION
- added support for systemd. If `platform==fedora` and `platform_version >= 15`, this will be used.
- added support for setting specific `uid` and `gid` on the logstash user for orgs that allocate specific IDs. leave nil to let system pick (default)
- made the `server.log_file` attribute optional. If it's set to empty string, logstash will be configured to log to stdout instead of a file. this is useful for systemd boxes which log stdout from services into journald. also useful for runit
  . Not so useful for init.d.
