### PR TITLE
Fixed #185 : Upstart job setgid for logstash agent

### DIFF
--- a/templates/default/logstash_agent.conf.erb
+++ b/templates/default/logstash_agent.conf.erb
@@ -13,7 +13,7 @@ chdir <%= node['logstash']['agent']['home'] %>
 <% if node['logstash']['agent']['upstart_with_sudo'] == false -%>
 setuid <%= node['logstash']['user'] %>
 
-<% if node['logstash']['supervisor_gid'] -%>
+<% unless node['logstash']['supervisor_gid'].to_s.empty? -%>
 setgid <%= node['logstash']['supervisor_gid'] %>
 <% end -%>
 


### PR DESCRIPTION
Don't output empty setgid line if supervisor_gid is present, but empty
