### PR TITLE
Concatenate config_file and config_dir in server erb variable

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -191,7 +191,7 @@ services.each do |type|
         owner 'root'
         group 'root'
         mode '0774'
-        variables(:config_file => node['logstash']['server']['config_dir'],
+        variables(:config_file => "#{node['logstash']['server']['config_dir']}/#{node['logstash']['server']['config_file']}",
                   :home => node['logstash']['server']['home'],
                   :name => type,
                   :log_file => node['logstash']['server']['log_file'],


### PR DESCRIPTION
The @config_file variable used in init.logstash_server.erb points to the config directory but does not include the name of the file itself (node['logstash']['server']['config_file']).  Before I made this change the generated script would ignore any of our config changes. 

I believe the same issue occurs in agent.rb and logstash_agent.conf.erb but we have not tested it.
