### PR TITLE
README.md: Updated logstash server example for 1.2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,11 +436,10 @@ These examples show the legacy format and need to be updated for logstash >= 1.2
         :server => {
           :enable_embedded_es => false,
           :inputs => [
-            :amqp => {
+            :rabbitmq => {
               :type => "all",
               :host => "<IP OF RABBIT SERVER>",
-              :exchange => "rawlogs",
-              :name => "rawlogs_consumer"
+              :exchange => "rawlogs"
             }
           ],
           :filters => [
@@ -462,9 +461,7 @@ These examples show the legacy format and need to be updated for logstash >= 1.2
     )
     run_list(
       "role[elasticsearch_server]",
-      "recipe[logstash::server]",
-      "recipe[php::module_curl]",
-      "recipe[logstash::kibana]"
+      "recipe[logstash::server]"
     )
 
 


### PR DESCRIPTION
- In 1.2.2 rabbitmq now replaced the old deprecated amqp plugin. amqp plugin is removed from logstash 1.2.2
- Parameter 'name' is not in the list in 1.2.x docs, removed,logstash complained about it anyway http://logstash.net/docs/1.2.2/inputs/rabbitmq
- Curl and kibana recipes removed
