### PR TITLE
add installation of argparse, which is a dependency of the index cleaner

### DIFF
--- a/recipes/index_cleaner.rb
+++ b/recipes/index_cleaner.rb
@@ -9,6 +9,10 @@ python_pip "pyes" do
   action :install
 end
 
+python_pip "argparse" do
+  action :install
+end
+
 directory base_dir do
   action :create
   mode "0755"


### PR DESCRIPTION
We stumbled upon this bug when setting up the index cleaner. It failed with the error:

```
Traceback (most recent call last):
  File "/opt/logstash/index_cleaner/logstash_index_cleaner.py", line 21, in <module>
    import argparse
ImportError: No module named argparse
```

So here's a fix.
