### PR TITLE
Fix init for agent on redhat

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -185,7 +185,7 @@ elsif node['logstash']['agent']['init_method'] == 'native'
     end
   elsif platform_family? "rhel", "fedora"
     template "/etc/init.d/logstash_agent" do
-      source "init.erb"
+      source "init.logstash_server.erb"
       owner "root"
       group "root"
       mode "0774"


### PR DESCRIPTION
init.erb is a non-existent template. Use init.logstash_server.erb instead.
