### PR TITLE
make java a more loosely coupled dependency

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,6 +3,7 @@
 metadata
 
 cookbook 'rabbitmq', git: 'git://github.com/opscode-cookbooks/rabbitmq.git'
+cookbook 'java'
 
 group :test do
   cookbook 'minitest-handler', git: 'git://github.com/btm/minitest-handler-cookbook.git'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@
 log_level = :info
 
 chef_run_list = %w[
+        java::default
         logstash::server
         logstash::agent
 ]
@@ -77,8 +78,8 @@ Vagrant.configure('2') do |config|
   # Common Settings
   config.omnibus.chef_version = 'latest'
   config.vm.hostname = 'logstash'
-  config.vm.network 'forwarded_port', guest: 9292, host: 9292
-  config.vm.network 'forwarded_port', guest: 9200, host: 9200
+  config.vm.network 'forwarded_port', guest: 9292, host: 8292
+  config.vm.network 'forwarded_port', guest: 9200, host: 8200
   config.vm.provider :virtualbox do |vb|
     vb.customize ['modifyvm', :id, '--memory', '1024']
   end

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -4,7 +4,6 @@
 # Recipe:: agent
 #
 #
-include_recipe 'java::default'
 include_recipe 'logstash::default'
 include_recipe 'yum::default'
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -10,7 +10,6 @@
 #
 #
 
-include_recipe 'java'
 include_recipe 'logstash::default'
 include_recipe 'logrotate'
 

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -1,6 +1,5 @@
 # Encoding: utf-8
 include_recipe 'build-essential'
-include_recipe 'java'
 include_recipe 'ant'
 include_recipe 'git'
 include_recipe 'logstash::default'

--- a/recipes/zero_mq_repo.rb
+++ b/recipes/zero_mq_repo.rb
@@ -4,7 +4,6 @@
 # Recipe:: zero_mq_repo
 #
 #
-include_recipe 'java::default'
 include_recipe 'yum::default'
 
 major_version = node['platform_version'].split('.').first.to_i


### PR DESCRIPTION
- Do not invoke java::default in seevral recipes, instead the user should call it using its run_list, if needed.
- Added java dependency in Berkshelf file (was only mentioned set in metadata.rb)
