### PR TITLE
Add support for the new Beaver config option.

### DIFF
--- a/recipes/beaver.rb
+++ b/recipes/beaver.rb
@@ -127,6 +127,8 @@ node['logstash']['beaver']['outputs'].each do |outs|
   end
 end
 
+conf['logstash_version'] = node['logstash']['server']['version'] >= '1.2' ? '1' : '0'
+
 output = outputs[0]
 log("multiple outpus detected, will consider only the first: #{output}") { level :warn } if outputs.length > 1
 cmd = "beaver  -t #{output} -c #{conf_file} -F #{format}"


### PR DESCRIPTION
Beaver >= 31 now requires you to set the config option `logstash_version`. This has been added to support the new Logstash 1.2 JSON schema. Assuming that the same cookbook is being used elsewhere in the infrastructure to install Logstash, this small change checks for the version of Logstash and adds the appropriate value for `logstash_version` to the `conf` hash.

This should resolve https://github.com/lusis/chef-logstash/issues/225 
