### PR TITLE
Create homedir attribute, ensure it's always available

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Attributes
 
 ## Default
 
+* `node['logstash']['homedir']` - the home directory of the logstash user
 * `node['logstash']['basedir']` - the base directory for all the
   Logstash components
 * `node['logstash']['user']` - the owner for all Logstash components

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,6 +8,7 @@ default['logstash']['supervisor_gid'] = node['logstash']['group']
 default['logstash']['pid_dir'] = '/var/run/logstash'
 default['logstash']['create_account'] = true
 default['logstash']['join_groups'] = []
+default['logstash']['homedir'] = '/var/lib/logstash'
 
 # roles/flags for various search/discovery
 default['logstash']['graphite_role'] = 'graphite_server'

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -53,7 +53,7 @@ end
     group node['logstash']['group']
   end
 
-  link "/var/lib/logstash/#{ldir}" do
+  link "#{node['logstash']['homedir']}/#{ldir}" do
     to "#{node['logstash']['agent']['home']}/#{ldir}"
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,13 +14,21 @@ if node['logstash']['create_account']
 
   user node['logstash']['user'] do
     group node['logstash']['group']
-    home '/var/lib/logstash'
+    home node['logstash']['homedir']
     system true
     action :create
     manage_home true
     uid node['logstash']['uid']
   end
 
+else
+  directory node['logstash']['homedir'] do
+    recursive true
+    action :create
+    group node['logstash']['group']
+    owner node['logstash']['user']
+    mode '0755'
+  end
 end
 
 directory node['logstash']['basedir'] do

--- a/recipes/haproxy.rb
+++ b/recipes/haproxy.rb
@@ -17,7 +17,8 @@ directory "#{node['logstash']['server']['home']}/apache_logs" do
   group node['logstash']['group']
 end
 
-link '/var/lib/logstash/apache_logs' do
+apache_logs = "#{node['logstash']['homedir']}/apache_logs"
+link apache_logs do
   to "#{node['logstash']['server']['home']}/apache_logs"
 end
 


### PR DESCRIPTION
When installing the agent recipe, with create_account set to false, the recipe will fail. This is because the directory /var/lib/logstash has not been created.
- add homedir attribute, remove hard coded references to /var/lib/logstash
- make sure it is created, even if the user is not
