### PR TITLE
remove the rabbitmq dependency otherwise it will install rabbitmq, even ...

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ version          '0.8.1'
   supports os
 end
 
-%w{ build-essential runit git ant java logrotate rabbitmq yum python }.each do |ckbk|
+%w{ build-essential runit git ant java logrotate yum python }.each do |ckbk|
   depends ckbk
 end
 


### PR DESCRIPTION
node['logstash']['install_rabbitmq'] = false doesn't do anything if this is a dependency
