### PR TITLE
The test machine needs to have Java installed as well.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,6 +18,7 @@ suites:
   - name: server
     run_list:
       - recipe[apt::default]
+      - recipe[java::default]
       - recipe[logstash::server]
     attributes:
       java:


### PR DESCRIPTION
The kitchen test failed out of the box for me since the launched test machine lacked Java.
I just added the Java recipe to the run list.
