### PR TITLE
data-driven config: handle a sequence of plugins inside a block

### DIFF
--- a/libraries/logstash_conf.rb
+++ b/libraries/logstash_conf.rb
@@ -93,7 +93,7 @@ class Erubis::RubyEvaluator::LogstashConf
         result << indent(indent) + segment['condition'] + ' {' if segment['condition']
         if segment['block'].kind_of?(Array)
           segment['block'].each do |plugin|
-            plugin_to_arr(plugin, patterns_dir_plugins, patterns_dir, indent)
+            result << plugin_to_arr(plugin, patterns_dir_plugins, patterns_dir, indent)
           end
         else
           result << plugin_to_arr(segment['block'], patterns_dir_plugins, patterns_dir, indent)


### PR DESCRIPTION
The logstash_conf.rb template helper functions do not support rendering multiple instances of the same plugin within a block e.g. grok plugins against different fields in the message.
