### PR TITLE
Added support for defining the format and the exclude filter in beaver.conf

### DIFF
--- a/templates/default/beaver.conf.erb
+++ b/templates/default/beaver.conf.erb
@@ -7,8 +7,14 @@
 <%   file['path'].each do |path| -%>
 [<%= path %>]
 type: <%= file['type'] || 'file' %>
+<% if file.has_key?('format') -%>
+format: <%= file['format'] %>
+<% end -%>
 <% if file.has_key?('tags') -%>
 tags: <%= file['tags'].join(',') %>
+<% end -%>
+<% if file.has_key?('exclude') -%>
+exclude: (<%= file['exclude'].join('|') %>)
 <% end -%>
 <% if file.has_key?('add_field') -%>
 add_field: <%= file['add_field'].join(',') %>


### PR DESCRIPTION
Previously it would only be possible to specify the log format globally. The file exclude was not definable.

http://beaver.readthedocs.org/en/latest/user/usage.html#configuration-files
