### PR TITLE
Fix pattern templates is Hash to match attributes

### DIFF
--- a/resources/pattern.rb
+++ b/resources/pattern.rb
@@ -10,7 +10,7 @@ actions :create
 default_action :create if defined?(default_action)
 
 attribute :instance,    kind_of: String, name_attribute: true
-attribute :templates,   kind_of: Array
+attribute :templates,   kind_of: Hash
 attribute :variables,   kind_of: Hash
 attribute :path,        kind_of: String
 attribute :owner,       kind_of: String


### PR DESCRIPTION
Compare to https://github.com/lusis/chef-logstash/blob/logstash_1.4/attributes/default.rb#L46 which is `{}`

See also https://github.com/lusis/chef-logstash/blob/logstash_1.4/providers/pattern.rb#L22
