### PR TITLE
binary_upstart.erb doesn't join args array

### DIFF
--- a/templates/default/init/binary_upstart.erb
+++ b/templates/default/init/binary_upstart.erb
@@ -20,7 +20,7 @@ setgid <%= @supervisor_gid %>
 script
   export LOGSTASH_HOME="<%= @home %>"
   export HOME=$LOGSTASH_HOME
-  export LOGSTASH_OPTS="<%= @args %>"
+  export LOGSTASH_OPTS="<%= @args.join(' ') %>"
 
   <% if @upstart_with_sudo -%>
   exec sudo -u <%= @user %> $LOGSTASH_HOME/bin/logstash $LOGSTASH_OPTS


### PR DESCRIPTION
Use of `<%= @args %>`results in:

```
 export LOGSTASH_OPTS="["agent", "-f", "/opt/logstash/server/etc/conf.d/", "-l", "/opt/logstash/server/log/logstash.log", "-w", "1"]"
```

so use `@args.join` to get:

```
  export LOGSTASH_OPTS="agent -f /opt/logstash/server/etc/conf.d/ -l /opt/logstash/server/log/logstash.log -w 1"
```
