### PR TITLE
Enable template support for beaver's multiline options

### DIFF
--- a/templates/default/beaver.conf.erb
+++ b/templates/default/beaver.conf.erb
@@ -13,6 +13,12 @@ tags: <%= file['tags'].join(',') %>
 <% if file.has_key?('add_field') -%>
 add_field: <%= file['add_field'].join(',') %>
 <% end -%>
+<% if file.has_key?('regex_after') %>
+multiline_regex_after: <%= file['regex_after'] %>
+<% end %>
+<% if file.has_key?('regex_before') %>
+multiline_regex_before: <%= file['regex_before'] %>
+<% end %>
 
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Beaver 30+ supports multiline log parsing, this enables support for multiline_regex_before and multiline_regex_after. 
