### PR TITLE
Fix #273; Add 1.4 LS_HEAP_SIZE support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,7 +35,7 @@ default['logstash']['instance']['default']['plugins_check_if_installed']  = 'lib
 
 default['logstash']['instance']['default']['log_file']       = 'logstash.log'
 default['logstash']['instance']['default']['xms']        = '1024M'
-default['logstash']['instance']['default']['xmx']        = '1024M'
+default['logstash']['instance']['default']['xmx']        = "#{(node.memory.total.to_i * 0.6).floor / 1024}m"
 default['logstash']['instance']['default']['java_opts']  = ''
 default['logstash']['instance']['default']['gc_opts']    = '-XX:+UseParallelOldGC'
 default['logstash']['instance']['default']['ipv4_only']  = false

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -26,7 +26,7 @@ def load_current_resource
   @group     = new_resource.group || attributes['group'] || defaults['group']
   @mode      = new_resource.mode || '0644'
   @path      = new_resource.path || "#{@basedir}/#{@instance}/etc/conf.d"
-  @service_name = new_resource.service_name || "logstash_#{@instance}"
+  @service_name = new_resource.service_name || @instance
 end
 
 action :create do

--- a/providers/pattern.rb
+++ b/providers/pattern.rb
@@ -30,7 +30,7 @@ end
 
 action :create do
   pattern = pattern_vars
-  # Chef::Log.info("config vars: #{conf.inspect}")
+  # Chef::Log.info("config vars: #{pattern.inspect}")
   pattern[:templates].each do |template, file|
     tp = template "#{pattern[:path]}/#{::File.basename(file).chomp(::File.extname(file))}" do
       source      file

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -125,6 +125,7 @@ action :enable do
                       home: svc[:home],
                       name: svc[:name],
                       command: svc[:command],
+                      max_heap: svc[:max_heap],
                       args: args,
                       user: svc[:user],
                       group: svc[:group],

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -18,4 +18,3 @@ attribute :description, kind_of: String
 attribute :user, kind_of: String
 attribute :group, kind_of: String
 attribute :templates_cookbook,    kind_of: String
-

--- a/templates/default/init/binary_upstart.erb
+++ b/templates/default/init/binary_upstart.erb
@@ -18,6 +18,7 @@ setgid <%= @supervisor_gid %>
 <% end -%>
 
 script
+  export LS_HEAP_SIZE="<%= @max_heap %>"
   export LOGSTASH_HOME="<%= @home %>"
   export HOME=$LOGSTASH_HOME
   export LOGSTASH_OPTS="<%= @args.join(' ') %>"

--- a/test/unit/spec/agent_spec.rb
+++ b/test/unit/spec/agent_spec.rb
@@ -7,6 +7,7 @@ describe 'logstash::agent' do
     let(:node) { runner.node }
     let(:chef_run) do
       # runner.node.set['logstash'] ...
+      runner.node.set['memory']['total'] = '1024000kb'
       runner.converge(described_recipe)
     end
     include_context 'stubs-common'

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -6,7 +6,7 @@ describe 'logstash::default' do
     let(:runner) { ChefSpec::Runner.new(::UBUNTU_OPTS) }
     let(:node) { runner.node }
     let(:chef_run) do
-      # runner.node.set['logstash'] ...
+      runner.node.set['memory']['total'] = '1024000kb'
       runner.converge(described_recipe)
     end
     include_context 'stubs-common'

--- a/test/unit/spec/lwrp_config_spec.rb
+++ b/test/unit/spec/lwrp_config_spec.rb
@@ -11,6 +11,7 @@ describe 'logstash::server' do
     let(:runner) { ChefSpec::Runner.new(::LWRP) }
     let(:node) { runner.node }
     let(:chef_run) do
+      runner.node.set['memory']['total'] = '1024000kb'
       runner.node.set['logstash']['instance']['server']['config_templates'] = {
         output_stdout: 'config/output_stdout.conf.erb'
       }

--- a/test/unit/spec/lwrp_pattern_spec.rb
+++ b/test/unit/spec/lwrp_pattern_spec.rb
@@ -8,6 +8,7 @@ describe 'logstash::server' do
     let(:node) { runner.node }
     let(:chef_run) do
       runner.node.merge(::UBUNTU_OPTS)
+      runner.node.set['memory']['total'] = '1024000kb'
       runner.node.set['logstash']['instance']['server']['pattern_templates'] = {
         'default' => 'patterns/custom_patterns.erb'
       }

--- a/test/unit/spec/server_spec.rb
+++ b/test/unit/spec/server_spec.rb
@@ -7,6 +7,7 @@ describe 'logstash::server' do
     let(:node) { runner.node }
     let(:chef_run) do
       # runner.node.set['logstash'] ...
+      runner.node.set['memory']['total'] = '1024000kb'
       runner.converge(described_recipe)
     end
     include_context 'stubs-common'
@@ -23,7 +24,7 @@ describe 'logstash::server' do
       expect(chef_run).to create_logstash_pattern('server')
     end
 
-    it 'calls the logstash_instance LWRP' do
+    it 'calls the logstash_service LWRP' do
       expect(chef_run).to enable_logstash_service('server')
       expect(chef_run).to start_logstash_service('server')
     end


### PR DESCRIPTION
logstash 1.4 was only getting 500mb heap size from /opt/logstash/server/bin/logstash since LS_HEAP_SIZE was not set. This rectifies that with a default of 60% available total memory.

Also, chefspec wasn't passing because of logstash_service[name] mismatch in issue#273; the service_name change in config.rb provider seems to take care of that.
