### PR TITLE
Replacing an orphaned variable in the logrotate path

### DIFF
--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -211,7 +211,7 @@ def logrotate(ls)
   @run_context.include_recipe 'logrotate::default'
 
   logrotate_app "logstash_#{name}" do
-    path "#{log_dir}/*.log"
+    path "#{ls[:homedir]}/log/*.log"
     size ls[:logrotate_size] if ls[:logrotate_use_filesize]
     frequency ls[:logrotate_rotate_frequency]
     rotate ls[:logrotate_max_backup]


### PR DESCRIPTION
log_dir seems to have been used at one time, but is no longer defined anywhere.
