### PR TITLE
Use correct group in init scripts

### DIFF
--- a/templates/default/init.logstash_server.erb
+++ b/templates/default/init.logstash_server.erb
@@ -12,6 +12,7 @@ export PIDFILE="$PIDDIR/<%= @name %>.pid"
 export LS_HOME="<%= @home %>"
 export LS_CONFIG="<%= @config_file %>"
 LS_USER="<%= node['logstash']['user'] %>"
+LS_GROUP="<%= node['logstash']['group'] %>"
 LS_LOG="<%= @log_file %>"
 LOGDIR="<%= ::File.dirname @log_file %>"
 export JAVA_OPTS="-server -Xms<%= @min_heap %> -Xmx<%= @max_heap %> -Djava.io.tmpdir=$LS_HOME/tmp/"
@@ -25,14 +26,14 @@ start() {
 
   if [ ! -d "$PIDDIR" ] ; then
     mkdir "$PIDDIR"
-    chown -R $LS_USER:$LS_USER $PIDDIR
+    chown -R $LS_USER:$LS_GROUP $PIDDIR
   fi
 
   if [ ! -d "$LOGDIR" ] ; then
     mkdir "$LOGDIR"
   fi
 
-  chown -R $LS_USER:$LS_USER $LOGDIR $PIDDIR
+  chown -R $LS_USER:$LS_GROUP $LOGDIR $PIDDIR
 
 
   if [ -f $PIDFILE ]; then

--- a/templates/default/init.logstash_web.erb
+++ b/templates/default/init.logstash_web.erb
@@ -11,6 +11,7 @@ PIDDIR="<%= node['logstash']['pid_dir'] %>"
 export PIDFILE="$PIDDIR/<%= @name %>.pid"
 export LS_HOME="<%= @home %>"
 LS_USER="<%= node['logstash']['user'] %>"
+LS_GROUP="<%= node['logstash']['group'] %>"
 export JAVA_OPTS="-server -Xms<%= @min_heap %> -Xmx<%= @max_heap %> -Djava.io.tmpdir=$LS_HOME/tmp/"
 BIN_SCRIPT="/usr/bin/env java $JAVA_OPTS -jar $LS_HOME/lib/logstash.jar web -a <%= node['logstash']['server']['web']['address'] + ' -p' + node['logstash']['server']['web']['port'] %> 2>&1 &  echo \$! > $PIDFILE"
 
@@ -22,10 +23,10 @@ start() {
 
   if [ ! -d "$PIDDIR" ] ; then
     mkdir "$PIDDIR"
-    chown -R $LS_USER:$LS_USER $PIDDIR
+    chown -R $LS_USER:$LS_GROUP $PIDDIR
   fi
 
-  chown -R $LS_USER:$LS_USER $LOGDIR $PIDDIR
+  chown -R $LS_USER:$LS_GROUP $LOGDIR $PIDDIR
 
 
   if [ -f $PIDFILE ]; then


### PR DESCRIPTION
The init scripts were using  the user as the group for the pid files, which breaks if a different group for logstash is specified because the logstash group is never created. I added group specification to the init files to correct this.
