### PR TITLE
service_query missing

### DIFF
--- a/libraries/logstash_util.rb
+++ b/libraries/logstash_util.rb
@@ -13,6 +13,7 @@ module Logstash
       service_ip = attributes["#{service}_ip"] || defaults["#{service}_ip"]
     else
       results = []
+      service_query = attributes["#{service}_query"] || defaults["#{service}_query"]
       Chef::Search::Query.new.search(:node, service_query) { |o| results << o }
       if !results.empty?
         service_ip = results[0]['ipaddress']


### PR DESCRIPTION
In the service_ip method, service_query is used in the place of the search query, but it is not defined prior to use. This pulls in the 'service_query' attribute from the named service attributes or default attributes.
