### PR TITLE
Fix not respecting the instance pattern cookbook

### DIFF
--- a/providers/pattern.rb
+++ b/providers/pattern.rb
@@ -23,7 +23,7 @@ def load_current_resource
   @variables = new_resource.variables || attributes['pattern_templates_variables'] || defaults['pattern_templates_variables']
   @owner     = new_resource.owner || attributes['user'] || defaults['user']
   @group     = new_resource.group || attributes['group'] || defaults['group']
-  @templates_cookbook = new_resource.templates_cookbook || defaults['pattern_templates_cookbook'] || defaults['pattern_templates_cookbook']
+  @templates_cookbook = new_resource.templates_cookbook || attributes['pattern_templates_cookbook'] || defaults['pattern_templates_cookbook']
   @mode      = new_resource.mode || '0644'
   @path      = new_resource.path || "#{@basedir}/#{@instance}/patterns"
 end


### PR DESCRIPTION
Resubmitting as I accidently closed this a while ago.

I think this is a simple oversight. In the config provider you can change the config_templates_cookbook in your wrapper and overwrite where the provider looks for the templates. Here you had defaults twice making it impossible to do so for patterns.
