### PR TITLE
Use the PIDDIR variable for pidfile location, not hard coded (and wrong) value

### DIFF
--- a/templates/default/init/tarball_init.logstash.erb
+++ b/templates/default/init/tarball_init.logstash.erb
@@ -8,7 +8,7 @@
 
 
 PIDDIR="/var/run/logstash"
-export PIDFILE="/var/run/logstash-<%= @name %>.pid"
+export PIDFILE="$PIDDIR/logstash-<%= @name %>.pid"
 export LS_HOME="<%= @home %>"
 export LS_HEAP_SIZE="<%= @max_heap %>"
 export LOGSTASH_OPTS="<%= @args.join(' ') %>"


### PR DESCRIPTION
The hardcoded value used is wrong, and no reason to use it. Simple fix to use the variable.
