### PR TITLE
bind host support + searching local nodes ip library method

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,6 +62,7 @@ default['logstash']['instance']['default']['service_templates_cookbook']  = 'log
 
 # roles/flags for various autoconfig/discovery components
 default['logstash']['instance']['default']['enable_embedded_es'] = false
+default['logstash']['instance']['default']['bind_host_interface'] = ''
 
 default['logstash']['instance']['default']['inputs'] = []
 default['logstash']['instance']['default']['filters'] = []

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -29,6 +29,13 @@ end
 embedded_es = node['logstash']['instance'][name]['enable_embedded_es'] || node['logstash']['instance']['default']['enable_embedded_es']
 es_cluster = node['logstash']['instance'][name]['elasticsearch_cluster'] || node['logstash']['instance']['default']['elasticsearch_cluster']
 
+bind_host_if = node['logstash']['instance'][name]['bind_host_interface'] || node['logstash']['instance']['default']['bind_host_interface']
+if (!bind_host_if.empty? )
+  bind_host = ::Logstash.get_ip_for_node(node, bind_host_if)
+else
+  bind_host = nil
+end
+
 my_templates  = {
   'input_syslog' => 'config/input_syslog.conf.erb',
   'output_stdout' => 'config/output_stdout.conf.erb',
@@ -40,6 +47,7 @@ logstash_config name do
   action [:create]
   variables(
     elasticsearch_ip: ::Logstash.service_ip(node, name, 'elasticsearch'),
+    bind_host: bind_host,
     elasticsearch_cluster: es_cluster,
     elasticsearch_embedded: embedded_es
   )

--- a/templates/default/config/output_elasticsearch.conf.erb
+++ b/templates/default/config/output_elasticsearch.conf.erb
@@ -6,5 +6,8 @@ output {
 <% elsif @elasticsearch_embedded -%>
     embedded => true
 <% end -%>
+<% if @bind_host -%>
+    bind_host => "<%= @bind_host %>"
+<% end -%>
   }
 }


### PR DESCRIPTION
The bind host support is especially needed when developing with Vagrant (since you can't use Vagrants own network). In production you might also have a private network for the ES -traffic.

By default the bind_host isn't used, but if the attributes value is changed the library searches for the interface's ip and uses that. So no hard coded ip's. 

I also added the same interface support to the ES-host search.
