### PR TITLE
1.4: fix test for installed java

### DIFF
--- a/test/integration/server/serverspec/server_spec.rb
+++ b/test/integration/server/serverspec/server_spec.rb
@@ -2,8 +2,8 @@
 require 'spec_helper'
 
 # Java 1.6
-describe package('openjdk-6-jre') do
-  it { should be_installed }
+describe command('java -version') do
+  it { should return_stdout /java version "1.7.\d+_\d+"/ }
 end
 
 # Logstash Instance


### PR DESCRIPTION
We switched to oracle java 1.7 for tests in 48c3ec06.
This PR removes the test for installed package openjdk-6 but just checks for the version string returned by java cli, since the oracle installation doesn't seem to leave behind a package that we can check for.
