### PR TITLE
1.4: Allow custom config templates via attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,7 +50,11 @@ default['logstash']['instance']['default']['base_config_cookbook']       = 'logs
 default['logstash']['instance']['default']['base_config']    = '' # set if want data driven
 
 default['logstash']['instance']['default']['config_file']                = ''
-default['logstash']['instance']['default']['config_templates']           = {}
+default['logstash']['instance']['default']['config_templates']           = {
+  'input_syslog' => 'config/input_syslog.conf.erb',
+  'output_stdout' => 'config/output_stdout.conf.erb',
+  'output_elasticsearch' => 'config/output_elasticsearch.conf.erb'
+}
 default['logstash']['instance']['default']['config_templates_cookbook']  = 'logstash'
 default['logstash']['instance']['default']['config_templates_variables'] = {}
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -37,14 +37,7 @@ else
   bind_host = nil
 end
 
-my_templates  = {
-  'input_syslog' => 'config/input_syslog.conf.erb',
-  'output_stdout' => 'config/output_stdout.conf.erb',
-  'output_elasticsearch' => 'config/output_elasticsearch.conf.erb'
-}
-
 logstash_config name do
-  templates my_templates
   action [:create]
   variables(
     elasticsearch_ip: ::Logstash.service_ip(node, name, 'elasticsearch'),


### PR DESCRIPTION
I believe the `my_templates` part in recipes/default.rb was left in by accident and that the default config templates were rather intended to be moved to attribute defaults.
If so, this PR does just this.

Otherwise I was unable to set my own config templates from a wrapper cookbook.
