### PR TITLE
Fix runit template cookbook

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -127,6 +127,7 @@ action :enable do
                 web_address: svc[:web_address],
                 web_port: svc[:web_port]
       )
+      cookbook  svc[:templates_cookbook]
     end
     new_resource.updated_by_last_action(ri.updated_by_last_action?)
   when 'native'


### PR DESCRIPTION
This PR adds the templates_cookbook parameter to the service definition.

Without this, when you use the logstash_service resource from another cookbook, the runit templates will be expected to be in that other cookbook. In order for the service provider to find the ones supplied from this cookbook, one would have to set attribute `service_templates_cookbook` to 'logstash', which already is the default.
