### PR TITLE
Fix the syntax for the curator delete cron.

### DIFF
--- a/providers/curator.rb
+++ b/providers/curator.rb
@@ -41,7 +41,7 @@ action :create do
   new_resource.updated_by_last_action(pi.updated_by_last_action?)
 
   cr = cron "curator-#{cur_instance}" do
-    command "curator --host #{::Logstash.service_ip(node, cur_instance, 'elasticsearch')} -d #{cur_days_to_keep} &> #{cur_log_file}"
+    command "curator --host #{::Logstash.service_ip(node, cur_instance, 'elasticsearch')} delete --older-than #{cur_days_to_keep} &> #{cur_log_file}"
     user    cur_user
     minute  cur_minute
     hour    cur_hour
@@ -66,7 +66,7 @@ action :delete do
   new_resource.updated_by_last_action(pi.updated_by_last_action?)
 
   cr = cron "curator-#{cur_instance}" do
-    command "curator --host #{::Logstash.service_ip(node, cur_instance, 'elasticsearch')} -d #{cur_days_to_keep} &> #{cur_log_file}"
+    command "curator --host #{::Logstash.service_ip(node, cur_instance, 'elasticsearch')} delete --older-than #{cur_days_to_keep} &> #{cur_log_file}"
     user    cur_user
     minute  cur_minute
     hour    cur_hour


### PR DESCRIPTION
For the Logstash 1.4 branch: this corrects the syntax for the elasticsearch curator cron job in the curator provider. 

Before:

```
[logstash]$ crontab -l
# Chef Name: curator-server
0 * * * * curator --host testing-es-logstashbalancer -d 1 &> /dev/null
[logstash]$ curator --host testing-es-logstashbalancer -d 1
usage: curator [-h] [-v] [--host HOST] [--url_prefix URL_PREFIX] [--port PORT]
               [--ssl] [--auth AUTH] [-t TIMEOUT] [--master-only] [-n] [-D]
               [--loglevel LOG_LEVEL] [-l LOG_FILE]
               {show,allocation,alias,snapshot,close,bloom,optimize,delete}
               ...
curator: error: argument command: invalid choice: '1' (choose from 'show', 'allocation', 'alias', 'snapshot', 'close', 'bloom', 'optimize', 'delete')
```

After fix:

```
[logstash]$ crontab -l
# Chef Name: curator-server
0 * * * * curator --host testing-es-logstashbalancer delete --older-than 1 &> /dev/null
[logstash]$ curator --host testing-es-logstashbalancer delete --older-than 1
<snip>
2014-07-23T14:12:08.717 INFO                        main:674  Done in 0:00:00.058335.
```

Tested with curator version 1.1.3.
