### PR TITLE
Correct exit codes on status

### DIFF
--- a/templates/default/init/java_init.logstash.erb
+++ b/templates/default/init/java_init.logstash.erb
@@ -140,11 +140,13 @@ status() {
   # NOT RUNNING
   if [[ ! $pid || ! -d "/proc/$pid" ]]; then
     echo "Logstash not running"
+    exit 3
   fi
 
   # STALE PID FOUND
   if [[ ! -d "/proc/$pid" && -f $PIDFILE ]]; then
     echo -e "\033[1;31;40m[!] Stale PID found in $PIDFILE\033[0m"
+    exit 1
   fi
 }
 

--- a/templates/default/init/tarball_init.logstash.erb
+++ b/templates/default/init/tarball_init.logstash.erb
@@ -134,11 +134,13 @@ status() {
   # NOT RUNNING
   if [[ ! $pid || ! -d "/proc/$pid" ]]; then
     echo "Logstash not running"
+    exit 3
   fi
 
   # STALE PID FOUND
   if [[ ! -d "/proc/$pid" && -f $PIDFILE ]]; then
     echo -e "\033[1;31;40m[!] Stale PID found in $PIDFILE\033[0m"
+    exit 1
   fi
 }
 


### PR DESCRIPTION
The status function on the init.d scripts does not exit with the correct status codes (reference http://refspecs.linuxbase.org/LSB_3.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html) when logstash either not running or not running with a stale PID file. This causes chef to not be correctly start logstash on RHEL systems (particularly AWS Linux) on converge. This PR adds the exit codes to the two init templates.
