### PR TITLE
Fix syntax for curator

### DIFF
--- a/providers/curator.rb
+++ b/providers/curator.rb
@@ -41,7 +41,7 @@ action :create do
   new_resource.updated_by_last_action(pi.updated_by_last_action?)
 
   cr = cron "curator-#{cur_instance}" do
-    command "curator --host #{::Logstash.service_ip(node, cur_instance, 'elasticsearch')} -d #{cur_days_to_keep} &> #{cur_log_file}"
+    command "curator --host #{::Logstash.service_ip(node, cur_instance, 'elasticsearch')} delete --older-than #{cur_days_to_keep} &> #{cur_log_file}"
     user    cur_user
     minute  cur_minute
     hour    cur_hour


### PR DESCRIPTION
Curator seems to have changed its syntax. This corrects the command in the cronjob. 
