### PR TITLE
Change default xms for logstash to a fraction of memory

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,7 +33,7 @@ default['logstash']['instance']['default']['plugins_install_type']   = 'tarball'
 default['logstash']['instance']['default']['plugins_check_if_installed']  = 'lib/logstash/filters/translate.rb'
 
 default['logstash']['instance']['default']['log_file']       = 'logstash.log'
-default['logstash']['instance']['default']['xms']        = '1024M'
+default['logstash']['instance']['default']['xms']        = "#{(node['memory']['total'].to_i * 0.2).floor / 1024}M"
 default['logstash']['instance']['default']['xmx']        = "#{(node['memory']['total'].to_i * 0.6).floor / 1024}M"
 default['logstash']['instance']['default']['java_opts']  = ''
 default['logstash']['instance']['default']['gc_opts']    = '-XX:+UseParallelOldGC'


### PR DESCRIPTION
When testing, minimum RAM (xms) would sometimes be higher than xmx. This sets a minimum based on memory available, assuming nothing.
