### PR TITLE
Status command of init script should return appropriate exit code

### DIFF
--- a/templates/default/init.logstash_server.erb
+++ b/templates/default/init.logstash_server.erb
@@ -141,6 +141,7 @@ status() {
   # NOT RUNNING
   if [[ ! $pid || ! -d "/proc/$pid" ]]; then
     echo "Logstash not running"
+    exit 3
   fi
 
   # STALE PID FOUND


### PR DESCRIPTION
We are noticing that chef doesn't always start, enable, or restart the service on CentOS 6.5. It turned out this was due to do one of the three init scripts missing an exit with a non-zero return code under the status() section.
