### PR TITLE
Updated docs due to error

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ If you want to use chef templates to drive your configs you'll want to set the f
 
 ```
 node['logstash']['agent']['config_file'] = "" # disable data drive templates ( can be left enabled if want both )
-node['logstash']['agent']['config_templates'] = ["apache"]
+node['logstash']['agent']['config_templates'] = { "apache" => "config/apache.conf.erb }
 node['logstash']['agent']['config_templates_cookbook'] = 'logstash'
 node['logstash']['agent']['config_templates_variables'] = { apache: { type: 'apache' } }
 ```


### PR DESCRIPTION
I was trying to add a new config_template to add an SQS input. I found the following line in the docs and tried to add it to chef_json in the Vagrantfile like so:

`logstash: {
   instance: {
     server: {
       config_templates: [
         'input_sqs'
       ]
     }
   }
 }`

However I got the following error.

`ERROR: Option templates must be a kind of Hash!  You passed ["input_sqs"]`

In the end I had to do the following: 

`logstash: {
   instance: {
     server: {
       config_templates: {
         'input_sqs' => 'config/input_sqs.conf.erb'
       }
     }
   }
 }`

This PR updates the docs to show that you need to pass a Hash and not an Array.

I am quite new to Chef, so if this is a mistake on my end I apologise.
