### PR TITLE
Fix Issue #333 - Add all instances attributes to config templates

### DIFF
--- a/providers/config.rb
+++ b/providers/config.rb
@@ -21,7 +21,7 @@ def load_current_resource
   @basedir = attributes['basedir'] || defaults['basedir']
   @templates = new_resource.templates || attributes['config_templates'] || defaults['config_templates']
   @templates_cookbook = new_resource.templates_cookbook  || attributes['config_templates_cookbook'] || defaults['config_templates_cookbook']
-  @variables = new_resource.variables.merge(defaults['config_templates_variables']).merge(attributes['config_templates_variables'])
+  @variables = new_resource.variables.merge(defaults['config_templates_variables'] || {}).merge(attributes['config_templates_variables'] || {})
   @owner     = new_resource.owner || attributes['user'] || defaults['user']
   @group     = new_resource.group || attributes['group'] || defaults['group']
   @mode      = new_resource.mode || '0644'


### PR DESCRIPTION
Summary: The variables are one thing that should be extensible but
due to use of || the specified variables in the agent recipe
always overrode any new varaibles added via attributes. This fixes
the problem by merging all defined attributes in order of
inheritence.
