### PR TITLE
honors plugins_install_type attribute correctly

### DIFF
--- a/resources/plugins.rb
+++ b/resources/plugins.rb
@@ -17,5 +17,5 @@ attribute :source_url, kind_of: String
 attribute :user, kind_of: String
 attribute :group, kind_of: String
 attribute :base_directory, kind_of: String
-attribute :install_type, kind_of: String, default: 'native'
+attribute :install_type, kind_of: String
 attribute :install_check, kind_of: String


### PR DESCRIPTION
Removes the default value for 'install_type' in 'resources/plugins.rb'. It was overriding the value of the 'plugins_install_type' attribute
