### PR TITLE
Build path using `instance_dir`, as opposed to `homedir`.

### DIFF
--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -210,7 +210,7 @@ def logrotate(ls)
   @run_context.include_recipe 'logrotate::default'
 
   logrotate_app "logstash_#{name}" do
-    path "#{ls[:homedir]}/log/*.log"
+    path "#{ls[:instance_dir]}/log/*.log"
     size ls[:logrotate_size] if ls[:logrotate_use_filesize]
     frequency ls[:logrotate_frequency]
     rotate ls[:logrotate_max_backup]


### PR DESCRIPTION
Fix for https://github.com/lusis/chef-logstash/issues/350
