### PR TITLE
`upstart_with_sudo` node attribute value now makes it through to the tar...

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -39,6 +39,7 @@ def load_current_resource
   @debug =  attributes['debug'] || defaults['debug']
   @install_type = attributes['install_type'] || defaults['install_type']
   @supervisor_gid = attributes['supervisor_gid'] || defaults['supervisor_gid']
+  @upstart_with_sudo = new_resource.upstart_with_sudo || attributes['upstart_with_sudo'] || defaults['upstart_with_sudo']
 end
 
 use_inline_resources
@@ -124,7 +125,8 @@ action :enable do
                       debug: svc[:debug],
                       log_file: svc[:log_file],
                       workers: svc[:workers],
-                      supervisor_gid: svc[:supervisor_gid]
+                      supervisor_gid: svc[:supervisor_gid],
+                      upstart_with_sudo: svc[:upstart_with_sudo]
                     )
         end
         new_resource.updated_by_last_action(tp.updated_by_last_action?)
@@ -269,6 +271,7 @@ def svc_vars
     debug: @debug,
     install_type: @install_type,
     supervisor_gid: @supervisor_gid,
+    upstart_with_sudo: @upstart_with_sudo,
     templates_cookbook: @templates_cookbook
   }
   svc

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -18,3 +18,4 @@ attribute :description, kind_of: String
 attribute :user, kind_of: String
 attribute :group, kind_of: String
 attribute :templates_cookbook,    kind_of: String
+attribute :upstart_with_sudo, kind_of: [TrueClass, FalseClass]


### PR DESCRIPTION
...ball init template.

This is necessary w.r.t. https://bugs.launchpad.net/upstart/+bug/812870
