### PR TITLE
Set default empty hash for logstash_config variables

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -12,7 +12,7 @@ default_action :create if defined?(default_action)
 attribute :instance,    kind_of: String, name_attribute: true
 attribute :service_name, kind_of: String
 attribute :templates,   kind_of: Hash
-attribute :variables,   kind_of: Hash
+attribute :variables,   kind_of: Hash, default: {}
 attribute :owner,       kind_of: String
 attribute :group,       kind_of: String
 attribute :mode,        kind_of: String


### PR DESCRIPTION
The logstash_config LWRP fails unless you pass in a hash for
`variables`. But what if you don't want any variables?! We can just
assume a default empty hash.
