### PR TITLE
The recent switch to upstart init style on CentOS 6.5 causes TK suite to fail

### DIFF
--- a/libraries/logstash_util.rb
+++ b/libraries/logstash_util.rb
@@ -45,10 +45,8 @@ module Logstash
     when 'debian'
       'sysvinit'
     when 'redhat', 'centos', 'scientific'
-      if platform_major_version <= 5
+      if platform_major_version <= 6
         'sysvinit'
-      elsif platform_major_version == 6
-        'upstart'
       else
         'systemd'
       end

--- a/test/unit/spec/util_spec.rb
+++ b/test/unit/spec/util_spec.rb
@@ -80,8 +80,8 @@ describe '::determine_native_init' do
     end
     context 'with 6' do
       let(:node) { { 'platform' => 'centos', 'platform_version' => '6' } }
-      it 'returns upstart' do
-        expect(Logstash.determine_native_init(node)).to eql('upstart')
+      it 'returns sysvinit' do
+        expect(Logstash.determine_native_init(node)).to eql('sysvinit')
       end
     end
     context 'with 7' do


### PR DESCRIPTION
In https://github.com/lusis/chef-logstash/commit/e150c1c05e8cbbde5e7af478e0c9207491975691, it looks like CentOS 6.5 was switched from using sysv style init to upstart. I'm concerned about the impact on existing installations that try to use the new cookbook version (they likely get double logstash services, right?). But also, it looks like it breaks during verify of the test kitchen suite (serverspec behaves like it expects sysv on centos 6, as it uses chkconfig and /sbin/service, which don't work with upstart -- see redhat7.rb, redhat.rb, linux.rb, and base.rb [in serverspec itself](https://github.com/serverspec/specinfra/tree/master/lib/specinfra/command)):

```
       /opt/chef/embedded/bin/ruby -I/tmp/busser/suites/serverspec -S /opt/chef/embedded/bin/rspec /tmp/busser/suites/serverspec/server_spec.rb --color --format documentation

       Command "java -version"
         should return stdout /java version "1.7.\d+_\d+"/

       Service "logstash_server"
       error reading information on service logstash_server: No such file or directory
         should be enabled (FAILED - 1)
         should be running (FAILED - 2)

       User "logstash"
         should exist []

       File "/opt/logstash/server/etc/conf.d/input_syslog.conf"
         should be file

       File "/opt/logstash/server/etc/conf.d/output_elasticsearch.conf"
         should be file

       File "/opt/logstash/server/etc/conf.d/output_stdout.conf"
         should be file

       Port "9200"
         should be listening

       Port "5959"
         should be listening

       Cron
         should have entry "0 * * * * curator --host 127.0.0.1 delete --older-than 31 &> /dev/null"

       Failures:

         1) Service "logstash_server" should be enabled
            On host ``
            Failure/Error: it { should be_enabled }
       env PATH=/sbin:/usr/bin:$PATH chkconfig --list logstash_server | grep 3:on
       expected Service "logstash_server" to be enabled
            # /tmp/busser/suites/serverspec/server_spec.rb:11:in `block (2 levels) in <top (required)>'

         2) Service "logstash_server" should be running
            On host ``
            Failure/Error: it { should be_running }
       env PATH=/sbin:/usr/bin:$PATH ps aux | grep -w -- logstash_server | grep -qv grep
       expected Service "logstash_server" to be running
            # /tmp/busser/suites/serverspec/server_spec.rb:12:in `block (2 levels) in <top (required)>'

       Finished in 0.3161 seconds
       10 examples, 2 failures

       Failed examples:

       rspec /tmp/busser/suites/serverspec/server_spec.rb:11 # Service "logstash_server" should be enabled
       rspec /tmp/busser/suites/serverspec/server_spec.rb:12 # Service "logstash_server" should be running
       /opt/chef/embedded/bin/ruby -I/tmp/busser/suites/serverspec -S /opt/chef/embedded/bin/rspec /tmp/busser/suites/serverspec/server_spec.rb --color --format documentation failed
       Ruby Script [/tmp/busser/gems/gems/busser-serverspec-0.2.7/lib/busser/runner_plugin/../serverspec/runner.rb /tmp/busser/suites/serverspec] exit code was 1
>>>>>> Verify failed on instance <server-centos-65>.
```
