### PR TITLE
Cannot reuse a template

### DIFF
--- a/providers/config.rb
+++ b/providers/config.rb
@@ -33,8 +33,8 @@ use_inline_resources
 action :create do
   conf = conf_vars
   # Chef::Log.info("config vars: #{conf.inspect}")
-  conf[:templates].each do |_template, file|
-    tp = template "#{conf[:path]}/#{::File.basename(file).chomp(::File.extname(file))}" do
+  conf[:templates].each do |template, file|
+    tp = template "#{conf[:path]}/#{::File.basename(template).chomp(::File.extname(template))}" do
       source      file
       cookbook    conf[:templates_cookbook]
       owner       conf[:owner]


### PR DESCRIPTION
Due to the way the config LWRP works, it will always use the template's source file name for the final name in the logstash configuration directory:

``` ruby
action :create do
  conf = conf_vars
  # Chef::Log.info("config vars: #{conf.inspect}")
  conf[:templates].each do |_template, file|
    tp = template "#{conf[:path]}/#{::File.basename(file).chomp(::File.extname(file))}" do
      source      file
      cookbook    conf[:templates_cookbook]
      owner       conf[:owner]
      group       conf[:group]
      mode        conf[:mode]
      variables   conf[:variables]
      action      :create
    end
    new_resource.updated_by_last_action(tp.updated_by_last_action?)
  end
end
```

I tried to use a generic template file for two different configuration files, but because `file` is used to name the final template resource, the second overwrites the first. It seems like this really should be using `_template` for the name of the template resource.
