### PR TITLE
Added run settings based on tarball for agent config

### DIFF
--- a/templates/default/sv-logstash_agent-run.erb
+++ b/templates/default/sv-logstash_agent-run.erb
@@ -12,8 +12,16 @@ LOGSTASH_OPTS="$LOGSTASH_OPTS -vv"
 <% end -%>
 LOGSTASH_OPTS="$LOGSTASH_OPTS -l $LOGSTASH_HOME/log/<%= @options[:log_file] %>"
 export LOGSTASH_OPTS="$LOGSTASH_OPTS -w <%= @options[:workers] %>"
-<% if @options[:supervisor_gid] -%>
-HOME=$LOGSTASH_HOME exec chpst -u <%= @options[:user] %>:<%= @options[:supervisor_gid] %> java $JAVA_OPTS $GC_OPTS -jar $LOGSTASH_HOME/lib/logstash.jar $LOGSTASH_OPTS
+<% if @options[:install_type] == 'tarball' -%>
+<%    if @options[:supervisor_gid] -%>
+HOME=$LOGSTASH_HOME exec chpst -u <%= @options[:user] %>:<%= @options[:supervisor_gid] %> $LOGSTASH_HOME/bin/logstash $LOGSTASH_OPTS
+<%    else -%>
+HOME=$LOGSTASH_HOME exec chpst -u <%= @options[:user] %> $LOGSTASH_HOME/bin/logstash $LOGSTASH_OPTS
+<%    end -%>
 <% else -%>
+<%    if @options[:supervisor_gid] -%>
+HOME=$LOGSTASH_HOME exec chpst -u <%= @options[:user] %>:<%= @options[:supervisor_gid] %> java $JAVA_OPTS $GC_OPTS -jar $LOGSTASH_HOME/lib/logstash.jar $LOGSTASH_OPTS
+<%    else -%>
 HOME=$LOGSTASH_HOME exec chpst -u <%= @options[:user] %> java $JAVA_OPTS $GC_OPTS -jar $LOGSTASH_HOME/lib/logstash.jar $LOGSTASH_OPTS
+<%    end -%>
 <% end -%>


### PR DESCRIPTION
Tarball versions of logstash don't seem to have a jar file. For some
reason this doesn't seem to have been added to the agent run config
