### PR TITLE
set JAVA_HOME in runit script

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -21,6 +21,7 @@ def load_current_resource
   @user = new_resource.user || Logstash.get_attribute_or_default(node, @instance, 'user')
   @group = new_resource.group || Logstash.get_attribute_or_default(node, @instance, 'group')
   @log_file = Logstash.get_attribute_or_default(node, @instance, 'log_file')
+  @java_home = Logstash.get_attribute_or_default(node, @instance, 'java_home')
   @max_heap = Logstash.get_attribute_or_default(node, @instance, 'xmx')
   @min_heap = Logstash.get_attribute_or_default(node, @instance, 'xms')
   @gc_opts = Logstash.get_attribute_or_default(node, @instance, 'gc_opts')
@@ -64,6 +65,7 @@ action :enable do
       options(
                 name: svc[:name],
                 home: svc[:home],
+                java_home: svc[:java_home],
                 max_heap: svc[:max_heap],
                 min_heap: svc[:min_heap],
                 gc_opts: svc[:gc_opts],
@@ -105,6 +107,7 @@ action :enable do
                     user: svc[:user],
                     group: svc[:group],
                     description: svc[:description],
+                    java_home: svc[:max_heap],
                     max_heap: svc[:max_heap],
                     min_heap: svc[:min_heap],
                     gc_opts: svc[:gc_opts],
@@ -171,6 +174,7 @@ action :enable do
                   user: svc[:user],
                   group: svc[:group],
                   description: svc[:description],
+                  java_home: svc[:java_home],
                   max_heap: svc[:max_heap],
                   min_heap: svc[:min_heap],
                   gc_opts: svc[:gc_opts],
@@ -241,6 +245,7 @@ def svc_vars
     user: @user,
     group: @group,
     log_file: @log_file,
+    java_home: @java_home,
     max_heap: @max_heap,
     min_heap: @min_heap,
     java_opts: @java_opts,

--- a/templates/default/sv-logstash-run.erb
+++ b/templates/default/sv-logstash-run.erb
@@ -9,6 +9,9 @@ exec 2>&1
 export LS_HEAP_SIZE=<%= @options[:max_heap] %>
 export LOGSTASH_HOME="<%= @options[:home] %>"
 export GC_OPTS="<%= @options[:gc_opts] %>"
+<% if @options[:java_home] -%>
+export JAVA_HOME="<%= @options[:java_home] %>"
+<% end -%>
 export JAVA_OPTS="-server -Xms<%= @options[:min_heap] %> -Xmx<%= @options[:max_heap] %> -Djava.io.tmpdir=$LOGSTASH_HOME/tmp/ <%= @options[:java_opts] %> <%= '-Djava.net.preferIPv4Stack=true' if @options[:ipv4_only] %>"
 LOGSTASH_OPTS="agent -f $LOGSTASH_HOME/etc/conf.d"
 LOGSTASH_OPTS="$LOGSTASH_OPTS --pluginpath $LOGSTASH_HOME/lib"


### PR DESCRIPTION
The logstash script will use the JAVA_HOME environment variable if it is set.  This change exports JAVA_HOME in /etc/sv/logstash_[instance]/run so that a particular JVM can be specified under the instance in its attributes. 

Without this change, the logstash cookbook on Ubuntu 14.04 with Oracle JDK 1.7 will fail to start the logstash service (using runit) with the following error:

2014-12-31_21:24:12.93170 Error occurred during initialization of VM
2014-12-31_21:24:12.93171 Incompatible minimum and maximum heap sizes specified
