### PR TITLE
Use systemd for Debian 8 (Jessie)

### DIFF
--- a/libraries/logstash_util.rb
+++ b/libraries/logstash_util.rb
@@ -44,7 +44,11 @@ module Logstash
         'sysvinit'
       end
     when 'debian'
-      'sysvinit'
+      if platform_major_version <= 7
+        'sysvinit'
+      else
+        'systemd'
+      end
     when 'redhat', 'centos', 'scientific'
       if platform_major_version <= 6
         'sysvinit'

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -143,6 +143,7 @@ action :enable do
         variables(
           home: svc[:home],
           user: svc[:user],
+          max_heap: svc[:max_heap],
           supervisor_gid: svc[:supervisor_gid],
           args: args
                   )

--- a/templates/default/config/input_syslog.conf.erb
+++ b/templates/default/config/input_syslog.conf.erb
@@ -3,6 +3,10 @@ input {
     port => "5959"
     type => "syslog"
   }
+  udp {
+    port => "514"
+    type => "syslog"
+  }
 }
 
 filter {

--- a/templates/default/init/systemd/tarball.erb
+++ b/templates/default/init/systemd/tarball.erb
@@ -8,6 +8,7 @@ Group=<%= @supervisor_gid %>
 WorkingDirectory=<%= @home %>
 Environment="LOGSTASH_HOME=<%= @home %>
 Environment="HOME=<%= @home %>
+Environment="LS_HEAP_SIZE=<%= @max_heap %>
 ExecStart=<%= "#{@home}/bin/logstash #{@args.join(' ')}" %>
 Restart=on-failure
 RestartSec=30


### PR DESCRIPTION
Update determine_native_init to return 'systemd' when Debian 8 is in use.

I'd suggest using node['init_package'] to reduce some of the code in this method.
