### PR TITLE
optionally specify log directory 

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,7 @@ default['logstash']['instance_default']['plugins_checksum']       = '7497ca3614b
 default['logstash']['instance_default']['plugins_install_type']   = 'tarball' # native|tarball
 default['logstash']['instance_default']['plugins_check_if_installed']  = 'lib/logstash/filters/translate.rb'
 
+default['logstash']['instance_default']['log_dir']    = nil # defaults to @instance_dir/log
 default['logstash']['instance_default']['log_file']   = 'logstash.log'
 default['logstash']['instance_default']['java_home']  = '/usr/lib/jvm/java-6-openjdk' # openjdk6 on ubuntu
 default['logstash']['instance_default']['xms']        = "#{(node['memory']['total'].to_i * 0.2).floor / 1024}M"

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -20,6 +20,7 @@ def load_current_resource
   @command = new_resource.command || "#{@home}/bin/logstash"
   @user = new_resource.user || Logstash.get_attribute_or_default(node, @instance, 'user')
   @group = new_resource.group || Logstash.get_attribute_or_default(node, @instance, 'group')
+  @log_dir = Logstash.get_attribute_or_default(node, @instance, 'log_dir') || "#{@home}/log"
   @log_file = Logstash.get_attribute_or_default(node, @instance, 'log_file')
   @max_heap = Logstash.get_attribute_or_default(node, @instance, 'xmx')
   @min_heap = Logstash.get_attribute_or_default(node, @instance, 'xms')
@@ -70,6 +71,7 @@ action :enable do
         java_opts: svc[:java_opts],
         ipv4_only: svc[:ipv4_only],
         debug: svc[:debug],
+        log_dir: svc[:log_dir],
         log_file: svc[:log_file],
         workers: svc[:workers],
         install_type: svc[:install_type],
@@ -111,6 +113,7 @@ action :enable do
           java_opts: svc[:java_opts],
           ipv4_only: svc[:ipv4_only],
           debug: svc[:debug],
+          log_dir: svc[:log_dir],
           log_file: svc[:log_file],
           workers: svc[:workers],
           supervisor_gid: svc[:supervisor_gid],
@@ -177,6 +180,7 @@ action :enable do
           java_opts: svc[:java_opts],
           ipv4_only: svc[:ipv4_only],
           debug: svc[:debug],
+          log_dir: svc[:log_dir],
           log_file: svc[:log_file],
           workers: svc[:workers],
           supervisor_gid: svc[:supervisor_gid],
@@ -203,7 +207,7 @@ def default_args
   svc = svc_vars
   args      = ['agent', '-f', "#{svc[:home]}/etc/conf.d/"]
   args.concat ['-vv'] if svc[:debug]
-  args.concat ['-l', "#{svc[:home]}/log/#{svc[:log_file]}"] if svc[:log_file]
+  args.concat ['-l', "#{svc[:log_dir]}/#{svc[:log_file]}"] if svc[:log_file]
   args.concat ['-w', svc[:workers].to_s] if svc[:workers]
   args
 end
@@ -240,6 +244,7 @@ def svc_vars
     chdir: @chdir,
     user: @user,
     group: @group,
+    log_dir: @log_dir,
     log_file: @log_file,
     max_heap: @max_heap,
     min_heap: @min_heap,

--- a/resources/instance.rb
+++ b/resources/instance.rb
@@ -26,6 +26,7 @@ attribute :group, kind_of: String
 attribute :create_account, kind_of: [TrueClass, FalseClass]
 attribute :logrotate_enable, kind_of: [TrueClass, FalseClass]
 attribute :user_opts, kind_of: [Hash]
+attribute :log_dir, kind_of: [String]
 attribute :logrotate_size, kind_of: [String]
 attribute :logrotate_use_filesize, kind_of: [TrueClass, FalseClass]
 attribute :logrotate_frequency, kind_of: [String]

--- a/templates/default/init/sysvinit/tarball.erb
+++ b/templates/default/init/sysvinit/tarball.erb
@@ -15,7 +15,7 @@ export LOGSTASH_OPTS="<%= @args.join(' ') %>"
 LS_USER="<%= @user %>"
 LS_GROUP="<%= @group %>"
 LS_LOG="<%= @log_file %>"
-LOGDIR="<%= ::File.dirname @log_file %>"
+LOGDIR="<%= @log_dir %>"
 export JAVA_OPTS="-server -Xms<%= @min_heap %> -Xmx<%= @max_heap %> -Djava.io.tmpdir=$LS_HOME/tmp/ <%= @java_opts %> <%= '-Djava.net.preferIPv4Stack=true' if @ipv4_only %>"
 BIN_SCRIPT="/usr/bin/env $LS_HOME/bin/logstash $LOGSTASH_OPTS > $LS_LOG 2>&1 &  echo \$! > $PIDFILE"
 

--- a/templates/default/sv-logstash-run.erb
+++ b/templates/default/sv-logstash-run.erb
@@ -15,7 +15,7 @@ LOGSTASH_OPTS="$LOGSTASH_OPTS --pluginpath $LOGSTASH_HOME/lib"
 <% if @options[:debug] -%>
 LOGSTASH_OPTS="$LOGSTASH_OPTS -vv"
 <% end -%>
-LOGSTASH_OPTS="$LOGSTASH_OPTS -l $LOGSTASH_HOME/log/<%= @options[:log_file] %>"
+LOGSTASH_OPTS="$LOGSTASH_OPTS -l <%= @options[:log_dir] %>/<%= @options[:log_file] %>"
 export LOGSTASH_OPTS="$LOGSTASH_OPTS -w <%= @options[:workers] %>"
 <% if @options[:supervisor_gid] -%>
 HOME=$LOGSTASH_HOME exec chpst -u <%= @options[:user] %>:<%= @options[:supervisor_gid] %> $LOGSTASH_HOME/bin/logstash $LOGSTASH_OPTS


### PR DESCRIPTION
I have this request for a project, to customize the logstash logs directory. 
So I've introduced the 'log_dir' parameter.  It can be specified as a parameter in the logstash_instance resource or in the attributes. It defaults to "#{base_dir}/#{instance_name}" as before
