### PR TITLE
optionally setting plugin path (this is for 1.5.0 release of logstash)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,6 +41,7 @@ default['logstash']['instance_default']['java_opts']  = ''
 default['logstash']['instance_default']['gc_opts']    = '-XX:+UseParallelOldGC'
 default['logstash']['instance_default']['ipv4_only']  = false
 default['logstash']['instance_default']['debug']      = false
+default['logstash']['instance_default']['pluginpath']      = true
 default['logstash']['instance_default']['workers']    = 1
 
 default['logstash']['instance_default']['pattern_templates_cookbook']  = 'logstash'

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -30,6 +30,7 @@ def load_current_resource
   @chdir = @home
   @workers =  Logstash.get_attribute_or_default(node, @instance, 'workers')
   @debug =  Logstash.get_attribute_or_default(node, @instance, 'debug')
+  @pluginpath =  Logstash.get_attribute_or_default(node, @instance, 'pluginpath')
   @install_type = Logstash.get_attribute_or_default(node, @instance, 'install_type')
   @supervisor_gid = Logstash.get_attribute_or_default(node, @instance, 'supervisor_gid')
   @runit_run_template_name = Logstash.get_attribute_or_default(node, @instance, 'runit_run_template_name')
@@ -247,6 +248,7 @@ def svc_vars
     ipv4_only: @ipv4_only,
     workers: @workers,
     debug: @debug,
+    pluginpath: @pluginpath,
     install_type: @install_type,
     supervisor_gid: @supervisor_gid,
     templates_cookbook: @templates_cookbook,

--- a/templates/default/sv-logstash-run.erb
+++ b/templates/default/sv-logstash-run.erb
@@ -11,7 +11,9 @@ export LOGSTASH_HOME="<%= @options[:home] %>"
 export GC_OPTS="<%= @options[:gc_opts] %>"
 export JAVA_OPTS="-server -Xms<%= @options[:min_heap] %> -Xmx<%= @options[:max_heap] %> -Djava.io.tmpdir=$LOGSTASH_HOME/tmp/ <%= @options[:java_opts] %> <%= '-Djava.net.preferIPv4Stack=true' if @options[:ipv4_only] %>"
 LOGSTASH_OPTS="agent -f $LOGSTASH_HOME/etc/conf.d"
+<% if @options[:pluginpath] -%>
 LOGSTASH_OPTS="$LOGSTASH_OPTS --pluginpath $LOGSTASH_HOME/lib"
+<% end -%>
 <% if @options[:debug] -%>
 LOGSTASH_OPTS="$LOGSTASH_OPTS -vv"
 <% end -%>


### PR DESCRIPTION
I was changing values for installing the latest 1.5.0 logstash release and it would fail startup on ubuntu 14.04 because of --pluginpath options passed to it. This optionally sets those options if desired, so it will work when someone upgrades from 1.5.0rc2 to the official release.
