### PR TITLE
Added templates_local to logstash_config

### DIFF
--- a/libraries/logstash_util.rb
+++ b/libraries/logstash_util.rb
@@ -28,7 +28,7 @@ module Logstash
   end
 
   def self.get_attribute_or_default(node, instance_name, attribute_name)
-    instance_attr = {} unless node['logstash']['instance'][instance_name]
+    #instance_attr = {} unless node['logstash']['instance'][instance_name]
     instance_attr = deep_fetch(node, 'logstash', 'instance', instance_name, attribute_name)
     default_attr = deep_fetch(node, 'logstash', 'instance_default', attribute_name)
     instance_attr || default_attr

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ license          'Apache 2.0'
 description      'Installs/Configures logstash'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          '0.11.7'
+version          '0.11.8'
 
 %w(ubuntu debian redhat centos scientific amazon fedora).each do |os|
   supports os

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -14,6 +14,7 @@ def load_current_resource
   @instance  = new_resource.instance
   @basedir = Logstash.get_attribute_or_default(node, @instance, 'basedir')
   @templates = new_resource.templates || Logstash.get_attribute_or_default(node, @instance, 'config_templates')
+  @templates_local = new_resource.templates_local || false
   @templates_cookbook = new_resource.templates_cookbook || Logstash.get_attribute_or_default(node, @instance, 'config_templates_cookbook')
 
   # merge user overrides into defaults for configuration variables
@@ -36,6 +37,7 @@ action :create do
   conf[:templates].each do |template, file|
     tp = template "#{conf[:path]}/#{::File.basename(template).chomp(::File.extname(template))}" do
       source      file
+      local       conf[:templates_local]
       cookbook    conf[:templates_cookbook]
       owner       conf[:owner]
       group       conf[:group]
@@ -51,14 +53,15 @@ private
 
 def conf_vars
   conf = {
-    instance:   @instance,
-    templates:  @templates,
-    variables:  @variables,
-    path:       @path,
-    owner:      @owner,
-    group:      @group,
-    mode:       @mode,
-    service_name: @service_name,
+    instance:        @instance,
+    templates:       @templates,
+    templates_local: @templates_local,
+    variables:       @variables,
+    path:            @path,
+    owner:           @owner,
+    group:           @group,
+    mode:            @mode,
+    service_name:    @service_name,
     templates_cookbook:   @templates_cookbook
   }
   conf

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -18,3 +18,4 @@ attribute :group,       kind_of: String
 attribute :mode,        kind_of: String
 attribute :path,        kind_of: String
 attribute :templates_cookbook,    kind_of: String
+attribute :templates_local,       kind_of: [TrueClass, FalseClass], default: false


### PR DESCRIPTION
I've added new feature to `chef_config`, which is new parameter `templates_local` which value is been assigned to `local` attribute of `template` resource:
