### PR TITLE
Symbols are converted to strings by deep_fetch

### DIFF
--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -217,9 +217,9 @@ end
 
 def ls_vars
   ls = {
-    homedir: @useropts[:homedir],
-    uid: @useropts[:uid],
-    gid: @useropts[:gid],
+    homedir: @useropts['homedir'],
+    uid: @useropts['uid'],
+    gid: @useropts['gid'],
     source_url: @source_url,
     version: @version,
     checksum: @checksum,


### PR DESCRIPTION
This is the fix for issue #415. The deep_fetch use of `.to_s` converts all symbols to strings, which requires that future lookups be done using strings rather than symbols.