### PR TITLE
Ensure logstash instance restarts after logrotate

### DIFF
--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -211,6 +211,7 @@ def logrotate(ls)
     frequency ls[:logrotate_frequency]
     rotate ls[:logrotate_max_backup]
     options ls[:logrotate_options]
+    postrotate ["service logstash_#{name} restart"]
     create "664 #{ls[:user]} #{ls[:group]}"
   end
 end


### PR DESCRIPTION
Looks like in some cases copytruncate is not enough for logstash service as it hangs.

By always restarting the service, we can make sure that logstash service doesn't hang.