### PR TITLE
Update default logstash to 1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG for chef-logstash
 
+* MINOR - default logstash version 1.4.5
+
 ## 0.11.2
 * MINOR - default logstash version 1.4.2
 * MINOR - correct status code for initv scripts

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,14 +22,14 @@ default['logstash']['instance_default']['create_account'] = true
 default['logstash']['instance_default']['join_groups'] = []
 default['logstash']['instance_default']['homedir'] = '/var/lib/logstash'
 
-default['logstash']['instance_default']['version']        = '1.4.2'
-default['logstash']['instance_default']['source_url']     = 'https://download.elasticsearch.org/logstash/logstash/logstash-1.4.2.tar.gz'
-default['logstash']['instance_default']['checksum']       = 'd5be171af8d4ca966a0c731fc34f5deeee9d7631319e3660d1df99e43c5f8069'
+default['logstash']['instance_default']['version']        = '1.4.5'
+default['logstash']['instance_default']['source_url']     = 'https://download.elasticsearch.org/logstash/logstash/logstash-1.4.5.tar.gz'
+default['logstash']['instance_default']['checksum']       = 'ddb6fd2d26e87b13d87fa1495492a7346d45267df46eed29503df08d3e5d8a13'
 default['logstash']['instance_default']['install_type']   = 'tarball'
 
-default['logstash']['instance_default']['plugins_version']        = '1.4.2'
-default['logstash']['instance_default']['plugins_source_url']     = 'https://download.elasticsearch.org/logstash/logstash/logstash-contrib-1.4.2.tar.gz'
-default['logstash']['instance_default']['plugins_checksum']       = '7497ca3614ba9122159692cc6e60ffc968219047e88de97ecc47c2bf117ba4e5'
+default['logstash']['instance_default']['plugins_version']        = '1.4.5'
+default['logstash']['instance_default']['plugins_source_url']     = 'https://download.elasticsearch.org/logstash/logstash/logstash-contrib-1.4.5.tar.gz'
+default['logstash']['instance_default']['plugins_checksum']       = 'e4fa08cac70f97e30d4d043fcab817b72c301631713376c5c21824d5d89cae3e'
 default['logstash']['instance_default']['plugins_install_type']   = 'tarball' # native|tarball
 default['logstash']['instance_default']['plugins_check_if_installed']  = 'lib/logstash/filters/translate.rb'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,7 +31,7 @@ default['logstash']['instance_default']['plugins_version']        = '1.4.5'
 default['logstash']['instance_default']['plugins_source_url']     = 'https://download.elasticsearch.org/logstash/logstash/logstash-contrib-1.4.5.tar.gz'
 default['logstash']['instance_default']['plugins_checksum']       = 'e4fa08cac70f97e30d4d043fcab817b72c301631713376c5c21824d5d89cae3e'
 default['logstash']['instance_default']['plugins_install_type']   = 'tarball' # native|tarball
-default['logstash']['instance_default']['plugins_check_if_installed']  = 'lib/logstash/filters/translate.rb'
+default['logstash']['instance_default']['plugins_check_if_installed'] = 'lib/logstash/filters/translate.rb'
 
 default['logstash']['instance_default']['log_file']   = 'logstash.log'
 default['logstash']['instance_default']['java_home']  = '/usr/lib/jvm/java-6-openjdk' # openjdk6 on ubuntu
@@ -47,8 +47,8 @@ default['logstash']['instance_default']['pattern_templates_cookbook']  = 'logsta
 default['logstash']['instance_default']['pattern_templates']           = {}
 default['logstash']['instance_default']['pattern_templates_variables'] = {}
 
-default['logstash']['instance_default']['base_config_cookbook']       = 'logstash'
-default['logstash']['instance_default']['base_config']    = '' # set if want data driven
+default['logstash']['instance_default']['base_config_cookbook'] = 'logstash'
+default['logstash']['instance_default']['base_config'] = '' # set if want data driven
 
 default['logstash']['instance_default']['config_file']                = ''
 default['logstash']['instance_default']['config_templates']           = {}
@@ -56,7 +56,7 @@ default['logstash']['instance_default']['config_templates_cookbook']  = 'logstas
 default['logstash']['instance_default']['config_templates_variables'] = {}
 
 default['logstash']['instance_default']['init_method'] = 'runit'
-default['logstash']['instance_default']['service_templates_cookbook']  = 'logstash'
+default['logstash']['instance_default']['service_templates_cookbook'] = 'logstash'
 
 # default locations for runit templates
 default['logstash']['instance_default']['runit_run_template_name'] = 'logstash'

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -59,7 +59,7 @@ def conf_vars
     group:      @group,
     mode:       @mode,
     service_name: @service_name,
-    templates_cookbook:   @templates_cookbook
+    templates_cookbook: @templates_cookbook
   }
   conf
 end

--- a/providers/curator.rb
+++ b/providers/curator.rb
@@ -43,8 +43,9 @@ action :create do
   new_resource.updated_by_last_action(pi.updated_by_last_action?)
 
   server_ip = ::Logstash.service_ip(node, cur_instance, 'elasticsearch')
+  curator_args = "--host #{server_ip} delete indices --older-than #{cur_days_to_keep} --time-unit #{cur_time_unit} --timestring '#{cur_timestring}' --prefix #{cur_index_prefix} &> #{cur_log_file}"
   cr = cron "curator-#{cur_instance}" do
-    command "#{cur_bin_dir}/curator --host #{server_ip} delete indices --older-than #{cur_days_to_keep} --time-unit #{cur_time_unit} --timestring '#{cur_timestring}' --prefix #{cur_index_prefix} &> #{cur_log_file}"
+    command "#{cur_bin_dir}/curator #{curator_args}"
     user    cur_user
     minute  cur_minute
     hour    cur_hour
@@ -70,8 +71,10 @@ action :delete do
   end
   new_resource.updated_by_last_action(pi.updated_by_last_action?)
 
+  host = ::Logstash.service_ip(node, cur_instance, 'elasticsearch')
+  curator_args = "--host #{host} delete indices --older-than #{cur_days_to_keep} --time-unit #{cur_time_unit} --timestring '#{cur_timestring}' --prefix #{cur_index_prefix} 2>&1 > #{cur_log_file}"
   cr = cron "curator-#{cur_instance}" do
-    command "#{cur_bin_dir}/curator --host #{::Logstash.service_ip(node, cur_instance, 'elasticsearch')} delete indices --older-than #{cur_days_to_keep} --time-unit #{cur_time_unit} --timestring '#{cur_timestring}' --prefix #{cur_index_prefix} 2>&1 > #{cur_log_file}"
+    command "#{cur_bin_dir}/curator #{curator_args}"
     user    cur_user
     minute  cur_minute
     hour    cur_hour

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -46,7 +46,7 @@ end
 action :create do
   ls = ls_vars
 
-  if  ls[:create_account]
+  if ls[:create_account]
     ur = user ls[:user] do
       home ls[:homedir]
       system true

--- a/providers/pattern.rb
+++ b/providers/pattern.rb
@@ -51,7 +51,7 @@ def pattern_vars
     owner:      @owner,
     group:      @group,
     mode:       @mode,
-    templates_cookbook:   @templates_cookbook
+    templates_cookbook: @templates_cookbook
   }
   pattern
 end

--- a/providers/plugins.rb
+++ b/providers/plugins.rb
@@ -44,7 +44,7 @@ action :create do
       user    ls_user
       group   ls_group
       cwd     ls_instance_dir
-      notifies    :restart, "logstash_service[#{ls_instance}]"
+      notifies :restart, "logstash_service[#{ls_instance}]"
       # this is a temp workaround to make the plugin command idempotent.
       not_if { ::File.exist?("#{ls_instance_dir}/#{ls_install_check}") }
     end
@@ -61,7 +61,7 @@ action :create do
       version   ls_version
       path      ls_basedir
       action    [:put]
-      notifies    :restart, "logstash_service[#{ls_instance}]"
+      notifies  :restart, "logstash_service[#{ls_instance}]"
       # this is a temp workaround to ensure idempotent.
       not_if { ::File.exist?("#{ls_instance_dir}/#{ls_install_check}") }
     end

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -28,8 +28,8 @@ def load_current_resource
   @java_opts = Logstash.get_attribute_or_default(node, @instance, 'java_opts')
   @description = new_resource.description || @service_name
   @chdir = @home
-  @workers =  Logstash.get_attribute_or_default(node, @instance, 'workers')
-  @debug =  Logstash.get_attribute_or_default(node, @instance, 'debug')
+  @workers = Logstash.get_attribute_or_default(node, @instance, 'workers')
+  @debug = Logstash.get_attribute_or_default(node, @instance, 'debug')
   @install_type = Logstash.get_attribute_or_default(node, @instance, 'install_type')
   @supervisor_gid = Logstash.get_attribute_or_default(node, @instance, 'supervisor_gid')
   @runit_run_template_name = Logstash.get_attribute_or_default(node, @instance, 'runit_run_template_name')
@@ -78,7 +78,7 @@ action :enable do
         web_address: svc[:web_address],
         web_port: svc[:web_port]
       )
-      cookbook  svc[:templates_cookbook]
+      cookbook svc[:templates_cookbook]
       run_template_name svc[:runit_run_template_name]
       log_template_name svc[:runit_log_template_name]
     end
@@ -136,7 +136,7 @@ action :enable do
       new_resource.updated_by_last_action(ex.updated_by_last_action?)
       tp = template "/etc/systemd/system/#{svc[:service_name]}.service" do
         tp = source "init/systemd/#{svc[:install_type]}.erb"
-        cookbook  svc[:templates_cookbook]
+        cookbook svc[:templates_cookbook]
         owner 'root'
         group 'root'
         mode '0755'
@@ -159,7 +159,7 @@ action :enable do
     elsif native_init == 'sysvinit'
       tp = template "/etc/init.d/#{svc[:service_name]}" do
         source "init/sysvinit/#{svc[:install_type]}.erb"
-        cookbook  svc[:templates_cookbook]
+        cookbook svc[:templates_cookbook]
         owner 'root'
         group 'root'
         mode '0774'
@@ -201,7 +201,7 @@ private
 
 def default_args
   svc = svc_vars
-  args      = ['agent', '-f', "#{svc[:home]}/etc/conf.d/"]
+  args = ['agent', '-f', "#{svc[:home]}/etc/conf.d/"]
   args.concat ['-vv'] if svc[:debug]
   args.concat ['-l', "#{svc[:home]}/log/#{svc[:log_file]}"] if svc[:log_file]
   args.concat ['-w', svc[:workers].to_s] if svc[:workers]

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -9,12 +9,12 @@ name = 'agent'
 
 # these should all default correctly.  listing out for example.
 logstash_instance name do
-  action            :create
+  action :create
 end
 
 # services are hard! Let's go LWRP'ing.   FIREBALL! FIREBALL! FIREBALL!
 logstash_service name do
-  action      [:enable]
+  action [:enable]
 end
 
 logstash_config name do

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -15,11 +15,11 @@
 name = 'server'
 
 logstash_instance name do
-  action            :create
+  action :create
 end
 
 logstash_service name do
-  action      [:enable]
+  action [:enable]
 end
 
 logstash_config name do

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -9,7 +9,7 @@ actions :create
 
 default_action :create if defined?(default_action)
 
-attribute :instance,    kind_of: String, name_attribute: true
+attribute :instance, kind_of: String, name_attribute: true
 attribute :service_name, kind_of: String
 attribute :templates,   kind_of: Hash
 attribute :variables,   kind_of: Hash, default: {}
@@ -17,4 +17,4 @@ attribute :owner,       kind_of: String
 attribute :group,       kind_of: String
 attribute :mode,        kind_of: String
 attribute :path,        kind_of: String
-attribute :templates_cookbook,    kind_of: String
+attribute :templates_cookbook, kind_of: String

--- a/resources/pattern.rb
+++ b/resources/pattern.rb
@@ -16,4 +16,4 @@ attribute :path,        kind_of: String
 attribute :owner,       kind_of: String
 attribute :group,       kind_of: String
 attribute :mode,        kind_of: String
-attribute :templates_cookbook,    kind_of: String
+attribute :templates_cookbook, kind_of: String

--- a/test/unit/spec/lwrp_pattern_spec.rb
+++ b/test/unit/spec/lwrp_pattern_spec.rb
@@ -31,7 +31,7 @@ describe 'logstash::server' do
         group:    'logstash',
         mode:     '0644',
         variables: { 'test' => true },
-        action:   [:create]
+        action: [:create]
       )
     end
   end


### PR DESCRIPTION
Update the default to the latest patch version of 1.4.x logstash for important stability patches.
https://github.com/elastic/logstash/blob/1.4/CHANGELOG#L1-L18
