### PR TITLE
Enhance the systemd templates and add base_directory to the service resource

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -28,8 +28,8 @@ def load_current_resource
   @java_opts = Logstash.get_attribute_or_default(node, @instance, 'java_opts')
   @description = new_resource.description || @service_name
   @chdir = @home
-  @workers =  Logstash.get_attribute_or_default(node, @instance, 'workers')
-  @debug =  Logstash.get_attribute_or_default(node, @instance, 'debug')
+  @workers = Logstash.get_attribute_or_default(node, @instance, 'workers')
+  @debug = Logstash.get_attribute_or_default(node, @instance, 'debug')
   @install_type = Logstash.get_attribute_or_default(node, @instance, 'install_type')
   @supervisor_gid = Logstash.get_attribute_or_default(node, @instance, 'supervisor_gid')
   @runit_run_template_name = Logstash.get_attribute_or_default(node, @instance, 'runit_run_template_name')
@@ -137,7 +137,7 @@ action :enable do
       vars = svc_vars.merge(args: args)
       tp = template "/etc/systemd/system/#{svc[:service_name]}.service" do
         tp = source "init/systemd/#{svc[:install_type]}.erb"
-        cookbook  svc[:templates_cookbook]
+        cookbook svc[:templates_cookbook]
         owner 'root'
         group 'root'
         mode '0755'

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -20,3 +20,4 @@ attribute :group, kind_of: String
 attribute :templates_cookbook, kind_of: String
 attribute :runit_run_template_name, kind_of: String
 attribute :runit_log_template_name, kind_of: String
+attribute :base_directory, kind_of: String

--- a/templates/default/init/systemd/tarball.erb
+++ b/templates/default/init/systemd/tarball.erb
@@ -6,12 +6,16 @@ After=network.target
 User=<%= @user %>
 Group=<%= @supervisor_gid %>
 WorkingDirectory=<%= @home %>
-Environment="LOGSTASH_HOME=<%= @home %>
-Environment="HOME=<%= @home %>
-ExecStart=<%= "#{@home}/bin/logstash #{@args.join(' ')}" %>
+LimitNOFILE=<%= @nofile_soft %> <%= @nofile_hard %>
+Environment="LOGSTASH_HOME=<%= @home %>"
+Environment="HOME=<%= @home %>"
+Environment="LS_HEAP_SIZE=<%= @max_heap %>"
+Environment="GC_OPTS=<%= @gc_opts %>"
+Environment='JAVA_OPTS=-server -Xms<%= @min_heap %> -Xmx<%= @max_heap %> -Djava.io.tmpdir=<%= @home %>/tmp/ <%= @java_opts %> <%= "-Djava.net.preferIPv4Stack=true" if @ipv4_only %>'
+ExecStart=<%= @home %>/bin/logstash <%= @args.join(' ') %>
 Restart=on-failure
 RestartSec=30
-SyslogIdentifier=logstash_agent
+SyslogIdentifier=logstash_<%= @name %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
1. Adds base_directory to the service resource mirroring the pattern in the plugins and instance LWRPs. Doing so makes it easier and more consistent when being used as a LWRP in a wrapper cookbook.
2. Normalizes the systemd unit to the same feature level as the upstart and sysv init systems.