### PR TITLE
Support logstash V2.2.2 in centos

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ license          'Apache 2.0'
 description      'Installs/Configures logstash'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          '0.12.1'
+version          '0.12.2'
 
 %w(ubuntu debian redhat centos scientific amazon fedora).each do |os|
   supports os

--- a/templates/default/init/sysvinit/tarball.erb
+++ b/templates/default/init/sysvinit/tarball.erb
@@ -17,6 +17,7 @@ LS_GROUP="<%= @group %>"
 LS_LOG="<%= @log_file %>"
 LOGDIR="<%= ::File.dirname @log_file %>"
 export JAVA_OPTS="-server -Xms<%= @min_heap %> -Xmx<%= @max_heap %> -Djava.io.tmpdir=$LS_HOME/tmp/ <%= @java_opts %> <%= '-Djava.net.preferIPv4Stack=true' if @ipv4_only %>"
+export HEAP_DUMP_PATH="-XX:HeapDumpPath=${LS_HOME}/heapdump.hprof"
 BIN_SCRIPT="/usr/bin/env $LS_HOME/bin/logstash $LOGSTASH_OPTS > $LS_LOG 2>&1 &  echo \$! > $PIDFILE"
 
 if [ -f /etc/init.d/functions ] ; then


### PR DESCRIPTION
Added environment variable HEAP_DUMP_PATH to support logstash new release 2.2.2 in centos