### PR TITLE
Redirect STDOUT to /dev/null on restart by logrotate.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -21,3 +21,4 @@ Roman Gorodeckij (@holms)
 Dmitriy Budnik (@budnik)
 @Pneumatus
 Martin Smith (@martinb3)
+Stanisław Tuszyński (@stuszynski)

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -221,7 +221,7 @@ def logrotate(ls)
     frequency ls[:logrotate_frequency]
     rotate ls[:logrotate_max_backup]
     options ls[:logrotate_options]
-    postrotate ["service logstash_#{name} restart"]
+    postrotate ["service logstash_#{name} restart > /dev/null"]
     create "664 #{ls[:user]} #{ls[:group]}"
   end
 end


### PR DESCRIPTION
Restarting `logstash_server` by logrotate `postrotate` command was
outputing a runit status to STDOUT. It makes cron to send a message to
root on each daily logrotate.

```
~# logrotate --force /etc/logrotate.d/logstash_instance
ok: run: logstash_instance: (pid 22421) 0s
```

This fix redirects STDOUT messages to `/dev/null`.
