### PR TITLE
fixes systemd init script

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -147,6 +147,7 @@ action :enable do
         variables(
           home: svc[:home],
           user: svc[:user],
+          min_heap: svc[:min_heap],
           max_heap: svc[:max_heap],
           supervisor_gid: svc[:supervisor_gid],
           args: args


### PR DESCRIPTION
This PR fixes systemd init script for centos alike distributions.
Right now it fails with `Invalid initial heap size: -Xms` because of empty param.
This fix also makes it possible to run `kitchen test` for centos platform.