### PR TITLE
removes kibana_lwrp cookbook as integration dependency

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -6,7 +6,6 @@ metadata
 
 group :integration do
   cookbook 'apt'
-  cookbook 'kibana_lwrp'
   cookbook 'beaver'
   cookbook 'logstash-test', path: 'test/fixtures/cookbooks/logstash-test'
 end


### PR DESCRIPTION
Not used and prevents other cookbooks updates