### PR TITLE
fixes rspec warning

### DIFF
--- a/test/unit/spec/lwrp_pattern_spec.rb
+++ b/test/unit/spec/lwrp_pattern_spec.rb
@@ -2,9 +2,13 @@
 require_relative 'spec_helper'
 require_relative 'server_spec'
 
+::LWRP_PATTERN = {
+  step_into: ['logstash_pattern']
+}.merge(::UBUNTU_OPTS)
+
 describe 'logstash::server' do
   describe 'ubuntu' do
-    let(:runner) { ChefSpec::SoloRunner.new(step_into: ['logstash_pattern']) }
+    let(:runner) { ChefSpec::SoloRunner.new(::LWRP_PATTERN) }
     let(:node) { runner.node }
     let(:chef_run) do
       runner.node.merge(::UBUNTU_OPTS)


### PR DESCRIPTION
Fixes the following warning: WARNING: you must specify a 'platform' and 'version' to your ChefSpec Runner and/or Fauxhai constructor, in the future omitting these will become a hard error. A list of available platforms is available at https://github.com/customink/fauxhai/blob/master/PLATFORMS.md