### PR TITLE
adds ‘java’ cookbook to integration cookbooks

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -6,6 +6,7 @@ metadata
 
 group :integration do
   cookbook 'apt'
+  cookbook 'java'
   cookbook 'beaver'
   cookbook 'logstash-test', path: 'test/fixtures/cookbooks/logstash-test'
 end


### PR DESCRIPTION
Fixes test-kitchen run.
This cookbook was previously added by removed`kibana_lwrp` cookbook and now missing dependency