### PR TITLE
Chef13 support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,7 +2,7 @@
 driver:
   name: vagrant
 driver_config:
-  require_chef_omnibus: 12.7
+  require_chef_omnibus: 13.1
   customize:
     memory: 512
     cpus: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG for chef-logstash
 
+## 0.13.0
+* MAJOR - Chef13 support
+
 ## 0.12.0
 * MAJOR - logstash version 1.5.4
 * MINOR - systemd improvements

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ group :lint do
 end
 
 group :unit do
-  gem 'berkshelf', '~> 5.6'
-  gem 'chef', '~> 12.7'
+  gem 'berkshelf', '~> 6.1'
+  gem 'chef', '~> 13.1'
   gem 'chef-sugar'
   gem 'chefspec'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ license          'Apache-2.0'
 description      'Installs/Configures logstash'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          '0.12.1'
+version          '0.13.0'
 
 %w(ubuntu debian redhat centos scientific amazon fedora).each do |os|
   supports os
@@ -22,6 +22,6 @@ depends 'poise-python'
 depends 'curl'
 depends 'beaver'
 
-chef_version '>= 12.7' if respond_to?(:chef_version)
+chef_version '>= 13.0' if respond_to?(:chef_version)
 issues_url       'https://github.com/lusis/chef-logstash/issues'
 source_url       'https://github.com/lusis/chef-logstash'


### PR DESCRIPTION
Cookbook now supports latest Chef version.
@martinb3 Can you please release new version to supermarket.chef.io after merge