### PR TITLE
#491 - remove unused chef/mixin dependencies

### DIFF
--- a/providers/config.rb
+++ b/providers/config.rb
@@ -6,10 +6,6 @@
 #
 # Copyright 2014, John E. Vincent
 
-require 'chef/mixin/shell_out'
-require 'chef/mixin/language'
-include Chef::Mixin::ShellOut
-
 def load_current_resource
   @instance  = new_resource.instance
   @basedir = Logstash.get_attribute_or_default(node, @instance, 'basedir')

--- a/providers/curator.rb
+++ b/providers/curator.rb
@@ -6,10 +6,6 @@
 #
 # Copyright 2014, John E. Vincent
 
-require 'chef/mixin/shell_out'
-require 'chef/mixin/language'
-include Chef::Mixin::ShellOut
-
 def load_current_resource
   @instance = new_resource.instance || 'default'
   @days_to_keep = new_resource.days_to_keep || Logstash.get_attribute_or_default(node, @instance, 'curator_days_to_keep')

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -7,9 +7,6 @@
 # Copyright 2014, John E. Vincent
 
 require 'pathname'
-require 'chef/mixin/shell_out'
-require 'chef/mixin/language'
-include Chef::Mixin::ShellOut
 
 def load_current_resource
   @name = new_resource.name || 'default'

--- a/providers/pattern.rb
+++ b/providers/pattern.rb
@@ -6,10 +6,6 @@
 #
 # Copyright 2014, John E. Vincent
 
-require 'chef/mixin/shell_out'
-require 'chef/mixin/language'
-include Chef::Mixin::ShellOut
-
 def load_current_resource
   @instance  = new_resource.instance
   @basedir   = Logstash.get_attribute_or_default(node, @instance, 'basedir')

--- a/providers/plugins.rb
+++ b/providers/plugins.rb
@@ -6,10 +6,6 @@
 #
 # Copyright 2014, John E. Vincent
 
-require 'chef/mixin/shell_out'
-require 'chef/mixin/language'
-include Chef::Mixin::ShellOut
-
 def load_current_resource
   @name = new_resource.name || 'contrib'
   @instance = new_resource.instance || 'default'

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -7,9 +7,6 @@
 # Copyright 2014, John E. Vincent
 
 require 'pathname'
-require 'chef/mixin/shell_out'
-require 'chef/mixin/language'
-include Chef::Mixin::ShellOut
 
 def load_current_resource
   @instance = new_resource.instance


### PR DESCRIPTION
Requiring `chef/mixin/language` breaks in chef14. I'm not seeing that any of these mixins are used, and removing them seems to work on the handful of hosts I've tested.