### PR TITLE
#491 - Remove chef/mixin/language references to support Chef 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG for chef-logstash
 
+## 1.0.1
+
+* MINOR - Removed chef/mixin/language references to support Chef 14
+* MINOR - Pinned version for 'cucumber-core' and 'gherkin' in Gemfile
+* MINOR - Update Ubuntu version in specs
+
 ## 1.0.0
 
 * MAJOR - Get tests passing on Chef 12.7

--- a/Gemfile
+++ b/Gemfile
@@ -22,5 +22,7 @@ group :kitchen_vagrant do
   gem 'vagrant-wrapper'
 end
 
+gem 'cucumber-core', '3.2.0'
+gem 'gherkin', '5.1.0'
 gem 'rake'
 gem 'serverspec'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ license          'Apache-2.0'
 description      'Installs/Configures logstash'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          '1.0.0'
+version          '1.0.1'
 
 %w(ubuntu debian redhat centos scientific amazon fedora).each do |os|
   supports os

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -6,10 +6,6 @@
 #
 # Copyright 2014, John E. Vincent
 
-require 'chef/mixin/shell_out'
-require 'chef/mixin/language'
-include Chef::Mixin::ShellOut
-
 def load_current_resource
   @instance  = new_resource.instance
   @basedir = Logstash.get_attribute_or_default(node, @instance, 'basedir')

--- a/providers/curator.rb
+++ b/providers/curator.rb
@@ -6,10 +6,6 @@
 #
 # Copyright 2014, John E. Vincent
 
-require 'chef/mixin/shell_out'
-require 'chef/mixin/language'
-include Chef::Mixin::ShellOut
-
 def load_current_resource
   @instance = new_resource.instance || 'default'
   @days_to_keep = new_resource.days_to_keep || Logstash.get_attribute_or_default(node, @instance, 'curator_days_to_keep')

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -7,9 +7,6 @@
 # Copyright 2014, John E. Vincent
 
 require 'pathname'
-require 'chef/mixin/shell_out'
-require 'chef/mixin/language'
-include Chef::Mixin::ShellOut
 
 def load_current_resource
   @name = new_resource.name || 'default'

--- a/providers/pattern.rb
+++ b/providers/pattern.rb
@@ -6,10 +6,6 @@
 #
 # Copyright 2014, John E. Vincent
 
-require 'chef/mixin/shell_out'
-require 'chef/mixin/language'
-include Chef::Mixin::ShellOut
-
 def load_current_resource
   @instance  = new_resource.instance
   @basedir   = Logstash.get_attribute_or_default(node, @instance, 'basedir')

--- a/providers/plugins.rb
+++ b/providers/plugins.rb
@@ -6,10 +6,6 @@
 #
 # Copyright 2014, John E. Vincent
 
-require 'chef/mixin/shell_out'
-require 'chef/mixin/language'
-include Chef::Mixin::ShellOut
-
 def load_current_resource
   @name = new_resource.name || 'contrib'
   @instance = new_resource.instance || 'default'

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -7,9 +7,6 @@
 # Copyright 2014, John E. Vincent
 
 require 'pathname'
-require 'chef/mixin/shell_out'
-require 'chef/mixin/language'
-include Chef::Mixin::ShellOut
 
 def load_current_resource
   @instance = new_resource.instance

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -16,7 +16,7 @@ require_relative 'support/matchers'
 
 ::UBUNTU_OPTS = {
   platform:  'ubuntu',
-  version:   '12.04',
+  version:   '14.04',
   log_level: ::LOG_LEVEL
 }
 


### PR DESCRIPTION
This addresses the same issue (issue #491 ) as pull request #494 , however the Travis CI build now passes.

- Removed chef/mixin/language references to support Chef 14
- Pinned versions for 'cucumber-core' as well as 'gherkin'
- Bumped Ubuntu version in spec tests to support current fauxhai version.