### PR TITLE
When using runit, don't try to create the service everytime an action is run on it

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -226,7 +226,9 @@ def service_action(action)
     end
   when 'runit'
     @run_context.include_recipe 'runit::default'
-    sv = runit_service svc[:service_name]
+    sv = runit_service svc[:service_name] do
+        action(:nothing)
+    end
   end
   sv.run_action(action)
   sv.updated_by_last_action?

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -227,7 +227,7 @@ def service_action(action)
   when 'runit'
     @run_context.include_recipe 'runit::default'
     sv = runit_service svc[:service_name] do
-        action(:nothing)
+      action(:nothing)
     end
   end
   sv.run_action(action)


### PR DESCRIPTION
When using runit if logstash_service gets notified it will always try to enable the service first (creating some templates, etc) because runit's default_action is enable.

This change makes it so that we override the defaut_action when the resource is created. Then we can call whatever action on the created ressource.